### PR TITLE
fix: add namespaced git tags for monorepo semantic-release

### DIFF
--- a/packages/cli/.releaserc.json
+++ b/packages/cli/.releaserc.json
@@ -1,5 +1,6 @@
 {
   "branches": ["main"],
+  "tagFormat": "cli-v${version}",
   "plugins": [
     [
       "@semantic-release/commit-analyzer",

--- a/packages/sdk/.releaserc.json
+++ b/packages/sdk/.releaserc.json
@@ -1,5 +1,6 @@
 {
   "branches": ["main"],
+  "tagFormat": "sdk-v${version}",
   "plugins": [
     [
       "@semantic-release/commit-analyzer",


### PR DESCRIPTION
- Add 'sdk-v' prefix to SDK package tags (sdk-v1.0.0)
- Add 'cli-v' prefix to CLI package tags (cli-v1.0.0)
- Prevents tag collision between packages in monorepo
- Allows independent semantic-release for each package

This fixes the issue where CLI package wasn't being released because it was seeing SDK tags and assuming it had already been released.