### PR TITLE
chore(workspace)!: rename packages to remove platform prefix

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -94,7 +94,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     environment:
       name: production
-      url: https://github.com/aignostics/platform-typescript-sdk/releases
+      url: https://github.com/aignostics/typescript-sdk/releases
 
     steps:
       - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project are documented in GitHub Releases.
 
-Please visit the [GitHub Releases page](https://github.com/aignostics/platform-typescript-sdk/releases) to see the full changelog with detailed release notes.
+Please visit the [GitHub Releases page](https://github.com/aignostics/typescript-sdk/releases) to see the full changelog with detailed release notes.
 
 ## Why GitHub Releases?
 
@@ -15,9 +15,9 @@ We use GitHub Releases to automatically generate changelogs from commit messages
 
 ## Quick Links
 
-- 📦 [All Releases](https://github.com/aignostics/platform-typescript-sdk/releases)
-- 🏷️ [Latest Release](https://github.com/aignostics/platform-typescript-sdk/releases/latest)
-- 📋 [Compare Versions](https://github.com/aignostics/platform-typescript-sdk/compare)
+- 📦 [All Releases](https://github.com/aignostics/typescript-sdk/releases)
+- 🏷️ [Latest Release](https://github.com/aignostics/typescript-sdk/releases/latest)
+- 📋 [Compare Versions](https://github.com/aignostics/typescript-sdk/compare)
 
 ## Release Types
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ The official TypeScript SDK for the Aignostics Platform, providing type-safe acc
 
 ## Packages
 
-- **[@aignostics/platform-typescript-sdk](packages/sdk/)** - Core TypeScript SDK with auto-generated API clients
-- **[@aignostics/platform-cli](packages/cli/)** - Command-line interface for platform operations
+- **[@aignostics/sdk](packages/sdk/)** - Core TypeScript SDK with auto-generated API clients
+- **[@aignostics/cli](packages/cli/)** - Command-line interface for platform operations
 
 ## Features
 
@@ -21,13 +21,13 @@ The official TypeScript SDK for the Aignostics Platform, providing type-safe acc
 ### SDK Package
 
 ```bash
-npm install @aignostics/platform-typescript-sdk
+npm install @aignostics/sdk
 ```
 
 ### CLI Package
 
 ```bash
-npm install -g @aignostics/platform-cli
+npm install -g @aignostics/cli
 ```
 
 ## Usage
@@ -40,7 +40,7 @@ For detailed usage instructions, see the individual package documentation:
 ### Quick Start - SDK
 
 ```typescript
-import { PlatformSDK } from '@aignostics/platform-typescript-sdk';
+import { PlatformSDK } from '@aignostics/sdk';
 
 const sdk = new PlatformSDK({
   baseURL: 'https://api.aignostics.com',
@@ -52,7 +52,7 @@ const sdk = new PlatformSDK({
 
 ```bash
 # Install and use the CLI
-npm install -g @aignostics/platform-cli
+npm install -g @aignostics/cli
 aignostics-platform info
 ```
 
@@ -76,8 +76,8 @@ aignostics-platform info
 
 ```bash
 # Clone the repository
-git clone https://github.com/aignostics/platform-typescript-sdk.git
-cd platform-typescript-sdk
+git clone https://github.com/aignostics/typescript-sdk.git
+cd typescript-sdk
 
 # Install dependencies
 npm install
@@ -135,7 +135,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## Support
 
-For support, please open an issue on [GitHub](https://github.com/aignostics/platform-typescript-sdk/issues) or contact the development team.
+For support, please open an issue on [GitHub](https://github.com/aignostics/typescript-sdk/issues) or contact the development team.
 
 ---
 

--- a/docs/TOKEN_STORAGE.md
+++ b/docs/TOKEN_STORAGE.md
@@ -177,7 +177,7 @@ $ aignostics-platform logout
 ### Programmatic Usage
 
 ```typescript
-import { PlatformSDK } from '@aignostics/platform-typescript-sdk';
+import { PlatformSDK } from '@aignostics/sdk';
 import { hasValidToken, getCurrentToken } from './utils/token-storage';
 
 // Check if user is authenticated

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,11 +44,11 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aignostics/platform-cli": {
+    "node_modules/@aignostics/cli": {
       "resolved": "packages/cli",
       "link": true
     },
-    "node_modules/@aignostics/platform-typescript-sdk": {
+    "node_modules/@aignostics/sdk": {
       "resolved": "packages/sdk",
       "link": true
     },
@@ -19236,11 +19236,11 @@
       }
     },
     "packages/cli": {
-      "name": "@aignostics/platform-cli",
+      "name": "@aignostics/cli",
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
-        "@aignostics/platform-typescript-sdk": "*",
+        "@aignostics/sdk": "*",
         "@napi-rs/keyring": "^1.1.8",
         "express": "^5.1.0",
         "keytar": "^7.9.0",
@@ -19262,7 +19262,7 @@
       }
     },
     "packages/sdk": {
-      "name": "@aignostics/platform-typescript-sdk",
+      "name": "@aignostics/sdk",
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@aignostics/platform-monorepo",
+  "name": "@aignostics/monorepo",
   "version": "0.0.0-development",
   "description": "Monorepo for Aignostics Platform TypeScript SDK and CLI",
   "type": "module",
@@ -37,7 +37,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/aignostics/platform-typescript-sdk.git"
+    "url": "git+https://github.com/aignostics/typescript-sdk.git"
   },
   "keywords": [
     "aignostics",
@@ -49,9 +49,9 @@
   "author": "Aignostics",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/aignostics/platform-typescript-sdk/issues"
+    "url": "https://github.com/aignostics/typescript-sdk/issues"
   },
-  "homepage": "https://github.com/aignostics/platform-typescript-sdk#readme",
+  "homepage": "https://github.com/aignostics/typescript-sdk#readme",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",
     "access": "restricted"

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -5,7 +5,7 @@ Command-line interface for the Aignostics Platform.
 ## Installation
 
 ```bash
-npm install -g @aignostics/platform-cli
+npm install -g @aignostics/cli
 ```
 
 ## Usage

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "@aignostics/platform-cli",
+  "name": "@aignostics/cli",
   "version": "0.0.0-development",
-  "description": "CLI for the Aignostics Platform",
+  "description": "CLI for Aignostics",
   "type": "module",
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "bin": {
-    "aignostics-platform": "./dist/index.cjs"
+    "aignostics": "./dist/index.cjs"
   },
   "files": [
     "dist",
@@ -32,7 +32,7 @@
   "author": "Aignostics",
   "license": "MIT",
   "dependencies": {
-    "@aignostics/platform-typescript-sdk": "*",
+    "@aignostics/sdk": "*",
     "@napi-rs/keyring": "^1.1.8",
     "express": "^5.1.0",
     "keytar": "^7.9.0",

--- a/packages/cli/src/cli-functions.spec.ts
+++ b/packages/cli/src/cli-functions.spec.ts
@@ -10,7 +10,7 @@ import {
   listRunResults,
   createApplicationRun,
 } from './cli-functions.js';
-import { PlatformSDK, PlatformSDKHttp } from '@aignostics/platform-typescript-sdk';
+import { PlatformSDK, PlatformSDKHttp } from '@aignostics/sdk';
 import { AuthService } from './utils/auth.js';
 
 // Mock process.exit to prevent test runner from exiting
@@ -20,7 +20,7 @@ vi.stubGlobal('process', {
   exit: mockExit,
 });
 
-vi.mock('@aignostics/platform-typescript-sdk', () => ({
+vi.mock('@aignostics/sdk', () => ({
   PlatformSDKHttp: vi.fn(),
   PlatformSDK: vi.fn(),
 }));

--- a/packages/cli/src/cli-functions.ts
+++ b/packages/cli/src/cli-functions.ts
@@ -1,4 +1,4 @@
-import { PlatformSDKHttp, type ItemCreationRequest } from '@aignostics/platform-typescript-sdk';
+import { PlatformSDKHttp, type ItemCreationRequest } from '@aignostics/sdk';
 import { AuthService } from './utils/auth.js';
 import { readFileSync } from 'fs';
 import { join } from 'path';

--- a/packages/cli/src/package.json
+++ b/packages/cli/src/package.json
@@ -1,4 +1,4 @@
 {
-  "name": "@aignostics/platform-cli",
+  "name": "@aignostics/cli",
   "version": "0.0.0-development"
 }

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   treeshake: true,
   outDir: 'dist',
   external: [
-    '@aignostics/platform-typescript-sdk',
+    '@aignostics/sdk',
     '@napi-rs/keyring',
     'express',
     'keytar',

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -5,13 +5,13 @@ The TypeScript SDK for the Aignostics Platform.
 ## Installation
 
 ```bash
-npm install @aignostics/platform-typescript-sdk
+npm install @aignostics/sdk
 ```
 
 ## Usage
 
 ```typescript
-import { PlatformSDKHttp } from '@aignostics/platform-typescript-sdk';
+import { PlatformSDKHttp } from '@aignostics/sdk';
 
 // Create SDK instance with a token provider
 const sdk = new PlatformSDKHttp({

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@aignostics/platform-typescript-sdk",
+  "name": "@aignostics/sdk",
   "version": "0.0.0-development",
-  "description": "The TypeScript SDK for the Aignostics Platform",
+  "description": "The TypeScript SDK for Aignostics",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/scripts/generate-attributions.js
+++ b/scripts/generate-attributions.js
@@ -357,7 +357,8 @@ async function generateAttributions() {
       if (
         packagePath === '' ||
         packagePath.startsWith('packages/') ||
-        packagePath.includes('@aignostics/platform-')
+        packagePath.includes('@aignostics/sdk') ||
+        packagePath.includes('@aignostics/cli')
       ) {
         continue;
       }
@@ -367,7 +368,8 @@ async function generateAttributions() {
       // Skip duplicates and local packages
       if (
         dependencies.some(dep => dep.name === packageName) ||
-        packageName.includes('@aignostics/platform-')
+        packageName.includes('@aignostics/sdk') ||
+        packageName.includes('@aignostics/cli')
       ) {
         continue;
       }

--- a/scripts/minimal-test.sh
+++ b/scripts/minimal-test.sh
@@ -74,7 +74,7 @@ if npm publish --registry http://localhost:$PORT; then
         node:20-alpine \
         sh -c "
             npm config set registry http://verdaccio:4873
-            npm install -g @aignostics/platform-typescript-sdk
+            npm install -g @aignostics/sdk
             aignostics-platform --version
         "
     

--- a/scripts/simple-test.sh
+++ b/scripts/simple-test.sh
@@ -118,7 +118,7 @@ if npm publish --registry http://localhost:$VERDACCIO_PORT; then
             set -e
             npm config set @aignostics:registry http://verdaccio-simple-test:4873
             npm config set '//verdaccio-simple-test:4873/:_authToken=anonymous'
-            npm install -g @aignostics/platform-typescript-sdk
+            npm install -g @aignostics/sdk
             aignostics-platform --version
         "
     

--- a/scripts/test-node-compatibility.sh
+++ b/scripts/test-node-compatibility.sh
@@ -15,7 +15,7 @@ NC='\033[0m' # No Color
 # Configuration
 VERDACCIO_PORT=4873
 VERDACCIO_URL="http://verdaccio-test:4873"
-PACKAGE_NAME="@aignostics/platform-typescript-sdk"
+PACKAGE_NAME="@aignostics/sdk"
 VERDACCIO_CONTAINER="verdaccio-test"
 DOCKER_NETWORK="test-network"
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,4 @@
-sonar.projectKey=aignostics_platform-typescript-sdk
+sonar.projectKey=aignostics_typescript-sdk
 sonar.organization=aignostics
 sonar.projectName=Aignostics Platform TypeScript SDK
 sonar.projectVersion=1.0.0

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -24,8 +24,8 @@
     "preserveConstEnums": true,
     "baseUrl": ".",
     "paths": {
-      "@aignostics/platform-typescript-sdk": ["packages/sdk/src/index.ts"],
-      "@aignostics/platform-cli": ["packages/cli/src/index.ts"]
+      "@aignostics/sdk": ["packages/sdk/src/index.ts"],
+      "@aignostics/cli": ["packages/cli/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
BREAKING CHANGE: Package names have been simplified and renamed:
- @aignostics/platform-typescript-sdk is now @aignostics/sdk
- @aignostics/platform-cli is now @aignostics/cli

Users must update their installations:
- npm install @aignostics/sdk (instead of @aignostics/platform-typescript-sdk)
- npm install -g @aignostics/cli (instead of @aignostics/platform-cli)
- Update import statements: import { PlatformSDK } from "@aignostics/sdk"

All package references, imports, documentation, CI/CD workflows, and build configurations have been updated accordingly.