### PR TITLE
chore(OP-2780): pin GitHub Actions to commit SHA

### DIFF
--- a/.github/workflows/_codeql.yml
+++ b/.github/workflows/_codeql.yml
@@ -33,7 +33,7 @@ jobs:
             node-version: '20.x'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4 # v5.0.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # Add any setup steps before running the `github/codeql-action/init` action.
       # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -43,14 +43,14 @@ jobs:
 
       - if: matrix.language == 'javascript-typescript'
         name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@ebcb5b36ded6beda4ceefea6a8bc4cc885255bb3 # v3.34.1
         with:
           languages: javascript-typescript,actions
           build-mode: none
@@ -71,6 +71,6 @@ jobs:
           # location: ${{ matrix.location }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@ebcb5b36ded6beda4ceefea6a8bc4cc885255bb3 # v3.34.1
         with:
           category: '/language:${{ matrix.language }}'

--- a/.github/workflows/_report-to-ketryx.yml
+++ b/.github/workflows/_report-to-ketryx.yml
@@ -20,21 +20,21 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Download SDK test results
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
               continue-on-error: true
               with:
                 name: test-results-sdk
                 path: test-results/sdk/
             
             - name: Download CLI test results
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
               continue-on-error: true
               with:
                 name: test-results-cli
                 path: test-results/cli/
             
             - name: Report to Ketryx
-              uses: Ketryx/ketryx-github-action@v1.4.0
+              uses: Ketryx/ketryx-github-action@40b13ef68c772e96e58ec01a81f5b216d7710186 # v1.4.0
               with:
                 project: ${{ secrets.KETRYX_PROJECT }}
                 api-key: ${{ secrets.KETRYX_API_KEY }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -66,21 +66,21 @@ jobs:
 
       - name: Upload SDK test results
         if: matrix.node-version == '20.x'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: test-results-sdk
           path: packages/sdk/test-results/*.xml
 
       - name: Upload CLI test results
         if: matrix.node-version == '20.x'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: test-results-cli
           path: packages/cli/test-results/*.xml
 
       - name: Upload coverage to Codecov
         if: matrix.node-version == '20.x'
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3.1.6
         with:
           files: ./packages/sdk/coverage/lcov.info,./packages/cli/coverage/lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -90,7 +90,7 @@ jobs:
 
       - name: SonarQube Scan
         if: matrix.node-version == '20.x'
-        uses: SonarSource/sonarqube-scan-action@v6
+        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6.0.0
         with:
           args: >
             -Dsonar.javascript.lcov.reportPaths=packages/sdk/coverage/lcov.info,packages/cli/coverage/lcov.info
@@ -106,10 +106,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20.x'
           cache: 'npm'
@@ -127,7 +127,7 @@ jobs:
         run: npm run docs
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs
@@ -155,12 +155,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22.x'
           cache: 'npm'


### PR DESCRIPTION
## Action required: merge before ~April 20

Platform Engineering is enabling the GitHub org policy **"Require actions to be pinned to a full-length commit SHA"** (week 17). Once active, any workflow that references an action by version tag (e.g. `@v4`) will be **blocked from running**.

This PR pins all actions in this repo to their full commit SHA so workflows keep running after the policy is enforced.

**Please merge this PR before week 17 (April 20).** If you have questions, reach out in [#support-platform-engineering](https://aignostics.slack.com/archives/C06D26P439V) or see [OP-2780](https://aignx.atlassian.net/browse/OP-2780).

[OP-2780]: https://aignx.atlassian.net/browse/OP-2780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ