### PR TITLE
ci: harden E2E auth login test (failure diagnostics + profile-prompt handling)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -64,6 +64,14 @@ jobs:
           E2E_ADMIN_USER_EMAIL: ${{ vars.E2E_ADMIN_USER_EMAIL }}
           E2E_ADMIN_USER_PASSWORD: ${{ secrets.E2E_ADMIN_USER_PASSWORD }}
 
+      - name: Upload E2E auth failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: e2e-auth-diagnostics-${{ matrix.node-version }}
+          path: packages/cli/test-results/pkce-login-failure.*
+          if-no-files-found: ignore
+
       - name: Upload SDK test results
         if: matrix.node-version == '20.x'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/packages/cli/e2e/specs/1-Authentication.e2e.test.ts
+++ b/packages/cli/e2e/specs/1-Authentication.e2e.test.ts
@@ -113,9 +113,28 @@ describe('Authentication', () => {
         const continueButton = page.getByRole('button', { name: 'Continue', exact: true });
         await continueButton.click();
 
-        await page.waitForURL(/success|authorized|complete|localhost/, {
-          timeout: POST_LOGIN_NAVIGATION_TIMEOUT,
-        });
+        const callbackUrl = /success|authorized|complete|localhost/;
+
+        // A brand-new user is shown a one-time Auth0 Forms "Complete your profile"
+        // prompt asking for a full name before the flow redirects to the callback.
+        // Race the redirect against that prompt: fill and submit it if it appears,
+        // otherwise (profile already provisioned) the redirect happens directly.
+        const fullNameInput = page.locator('input[name="full_name"]');
+        const reachedCallback = await Promise.race([
+          page.waitForURL(callbackUrl, { timeout: POST_LOGIN_NAVIGATION_TIMEOUT }).then(() => true),
+          fullNameInput
+            .waitFor({ state: 'visible', timeout: POST_LOGIN_NAVIGATION_TIMEOUT })
+            .then(() => false),
+        ]);
+
+        if (!reachedCallback) {
+          await fullNameInput.fill('E2E Test Admin');
+          await page.locator('button.af-nextButton').click();
+
+          await page.waitForURL(callbackUrl, {
+            timeout: POST_LOGIN_NAVIGATION_TIMEOUT,
+          });
+        }
 
         await page.close();
         page = undefined;

--- a/packages/cli/e2e/specs/1-Authentication.e2e.test.ts
+++ b/packages/cli/e2e/specs/1-Authentication.e2e.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from 'vitest';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { executeCLI } from '../utils/command.js';
 import { FileSystemTokenStorage } from '../../src/utils/token-storage.js';
-import { chromium } from 'playwright';
+import { chromium, type Page } from 'playwright';
 
 const refreshToken = process.env.E2E_REFRESH_TOKEN || '';
 const environment = process.env.E2E_TEST_ENVIRONMENT || 'staging';
@@ -17,8 +20,37 @@ if (!adminEmail || !adminPassword) {
 }
 
 const PLAYWRIGHT_TIMEOUT = 10000;
+// The post-login redirect makes a full round-trip through Auth0 before landing
+// back on the local callback, which can take noticeably longer than a single
+// page interaction — give it more headroom (still well within PKCE_TEST_TIMEOUT).
+const POST_LOGIN_NAVIGATION_TIMEOUT = 30000;
 const PKCE_TEST_TIMEOUT = 60000;
 const INTERVAL_CHECK_TIMEOUT = 500;
+
+const DIAGNOSTICS_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '../../test-results');
+
+/**
+ * On failure the raw error is just a navigation timeout, which hides *why* the
+ * login did not complete (wrong/rotated credentials, an added Auth0 consent or
+ * bot-detection screen, or genuine latency). Dump the current URL, a screenshot
+ * and the page HTML so a failing CI run carries the evidence to tell these apart.
+ * Best-effort: never let diagnostics capture mask the original failure.
+ */
+async function capturePageDiagnostics(page: Page, label: string): Promise<void> {
+  try {
+    const currentUrl = page.url();
+    console.error(`[e2e-diagnostics] ${label}: page still at ${currentUrl}`);
+
+    await mkdir(DIAGNOSTICS_DIR, { recursive: true });
+    const base = resolve(DIAGNOSTICS_DIR, label);
+    await page.screenshot({ path: `${base}.png`, fullPage: true }).catch(() => undefined);
+    const html = await page.content().catch(() => '<unavailable>');
+    await writeFile(`${base}.html`, html);
+    await writeFile(`${base}.url.txt`, currentUrl);
+  } catch (diagnosticError) {
+    console.error('[e2e-diagnostics] failed to capture diagnostics:', diagnosticError);
+  }
+}
 
 describe('Authentication', () => {
   it(
@@ -29,6 +61,7 @@ describe('Authentication', () => {
       await annotate('TC-AUTH-PKCE', 'id');
 
       const browser = await chromium.launch({ headless: true });
+      let page: Page | undefined;
       try {
         let authUrl = '';
 
@@ -67,7 +100,7 @@ describe('Authentication', () => {
 
         console.log('Auth URL:', authUrl);
 
-        const page = await browser.newPage();
+        page = await browser.newPage();
         await page.goto(authUrl);
 
         await page.waitForSelector('input[name="username"], input[type="email"]', {
@@ -81,15 +114,21 @@ describe('Authentication', () => {
         await continueButton.click();
 
         await page.waitForURL(/success|authorized|complete|localhost/, {
-          timeout: PLAYWRIGHT_TIMEOUT,
+          timeout: POST_LOGIN_NAVIGATION_TIMEOUT,
         });
 
         await page.close();
+        page = undefined;
 
         const result = await cliPromise;
 
         expect(result.exitCode).toBe(0);
         expect(result.stdout).toMatch(/🔑 You are now authenticated and can use the SDK./i);
+      } catch (error) {
+        if (page) {
+          await capturePageDiagnostics(page, 'pkce-login-failure');
+        }
+        throw error;
       } finally {
         await browser.close();
       }


### PR DESCRIPTION
## Summary

Hardens the CLI PKCE login E2E test (`packages/cli/e2e/specs/1-Authentication.e2e.test.ts`) so it (a) captures useful evidence when it fails and (b) handles the one-time Auth0 "complete your profile" prompt shown to a freshly-provisioned test user. Touches only the E2E test and its CI job — **no library/runtime code changes.**

## Background — why

The `Should complete PKCE authentication login flow with browser automation` test had been red on `main` and every PR for ~2 weeks, surfacing only a generic `page.waitForURL: Timeout 10000ms exceeded`. The generic timeout hid the actual cause. The diagnostics added here (first commit) revealed it in a couple of runs:

1. **Invalid credentials** — Auth0 returned "Wrong email or password". Root cause was the `E2E_ADMIN_USER_EMAIL` **variable** still pointing at an old account while a new test user's password was put in the secret. **Fixed outside this PR** by updating the GH Actions variable/secret to the new `test_admin+tssdk@...` user.
2. **A post-login prompt** — with credentials fixed, login succeeded but landed on an Auth0 Forms **"Complete your profile → Full Name"** prompt (shown once for a user with no name set). The automation didn't fill it, so the flow never redirected. Handled here (second commit).

## What changed

**`1-Authentication.e2e.test.ts`**
- **Failure diagnostics** — on any failure in the login flow, capture the current page URL, a full-page screenshot, and the page HTML into `packages/cli/test-results/` (best-effort; never masks the original error).
- **Profile-prompt handling** — after the login submit, race the post-login redirect against the `full_name` prompt appearing. If the prompt shows, fill it (`"E2E Test Admin"`) and submit (`button.af-nextButton`), then wait for the callback; a user with a complete profile redirects straight through and skips it. This provisions the profile on the first run and stays robust afterward.
- **Timeout** — post-login navigation timeout raised 10s → 30s (that step makes a full Auth0 round-trip); still within the 60s per-test budget.

**`.github/workflows/ci-cd.yml`**
- On E2E failure, upload the captured diagnostics as an artifact (`e2e-auth-diagnostics-<node>`, `if: failure()`).

## Reviewer notes

- **Contract change worth a look:** the test now *self-provisions* its test user's profile rather than assuming a pre-provisioned account. Reasonable given the user is CI-managed, but please sanity-check that's acceptable.
- The prompt selectors (`input[name="full_name"]`, `button.af-nextButton`) were taken from the actual captured prompt HTML, not guessed.
- Verified green on CI (`test 18.x` + `20.x`), including SonarCloud and CodeQL.

## Merge / release note

Please **squash-merge** keeping a non-releasing type in the title (this PR is already titled `ci: …`). Both packages use semantic-release with the conventionalcommits preset and no path filtering, so a `fix:`/`feat:` commit would publish a patch/minor of **both** the SDK and CLI for a test-only change. `ci:` / `test:` / `chore:` do not trigger a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)