### PR TITLE
chore(workspace): introduce Renovate for automated dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "description": "Group patch updates",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["patch"],
+      "groupName": "patch updates",
+      "groupSlug": "patch"
+    },
+    {
+      "description": "Pin dev dependencies",
+      "matchDepTypes": ["devDependencies"],
+      "rangeStrategy": "pin"
+    }
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 3am on Monday"]
+  },
+  "postUpdateOptions": ["npmDedupe"],
+  "semanticCommits": "enabled",
+  "semanticCommitType": "chore",
+  "semanticCommitScope": "deps",
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 1
+}


### PR DESCRIPTION
## Summary

Adds Renovate to automate dependency updates, using the same base configuration as `platform-console`, with one difference: `rangeStrategy` uses the Renovate default for regular dependencies, and `pin` for dev dependencies.

Closes [TSSDK-69](https://aignx.atlassian.net/browse/TSSDK-69).

[TSSDK-69]: https://aignx.atlassian.net/browse/TSSDK-69?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ