### PR TITLE
chore(ci): use .node-version file for actions/setup-node

### DIFF
--- a/.github/workflows/_codeql.yml
+++ b/.github/workflows/_codeql.yml
@@ -30,7 +30,6 @@ jobs:
             build-mode: none
           - language: javascript-typescript
             build-mode: none
-            node-version: '20.x'
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -42,10 +41,10 @@ jobs:
       #   uses: actions/setup-example@v1
 
       - if: matrix.language == 'javascript-typescript'
-        name: Setup Node.js ${{ matrix.node-version }}
+        name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version-file: '.node-version'
           cache: 'npm'
 
       # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '24.x'
+          node-version-file: '.node-version'
           cache: 'npm'
 
       - name: Install dependencies
@@ -48,7 +48,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '24.x'
+          node-version-file: '.node-version'
           cache: 'npm'
 
       - name: Install dependencies
@@ -68,7 +68,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '24.x'
+          node-version-file: '.node-version'
           cache: 'npm'
 
       - name: Install dependencies
@@ -82,18 +82,14 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [18.x, 20.x]
-
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - name: Setup Node.js ${{ matrix.node-version }}
+      - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version-file: '.node-version'
           cache: 'npm'
 
       - name: Install dependencies
@@ -103,21 +99,18 @@ jobs:
         run: npx nx run-many -t test --coverage
 
       - name: Upload SDK test results
-        if: matrix.node-version == '20.x'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: test-results-sdk
           path: packages/sdk/test-results/*.xml
 
       - name: Upload CLI test results
-        if: matrix.node-version == '20.x'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: test-results-cli
           path: packages/cli/test-results/*.xml
 
       - name: Upload coverage reports
-        if: matrix.node-version == '20.x'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage-reports
@@ -130,18 +123,14 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [18.x, 20.x]
-
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - name: Setup Node.js ${{ matrix.node-version }}
+      - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version-file: '.node-version'
           cache: 'npm'
 
       - name: Install dependencies
@@ -165,7 +154,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: e2e-auth-diagnostics-${{ matrix.node-version }}
+          name: e2e-auth-diagnostics
           path: packages/cli/test-results/pkce-login-failure.*
           if-no-files-found: ignore
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '24.x'
+          node-version-file: '.node-version'
           cache: 'npm'
 
       - name: Install dependencies
@@ -66,7 +66,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '24.x'
+          node-version-file: '.node-version'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '24.x'
+          node-version-file: '.node-version'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
@@ -89,7 +89,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '24.x'
+          node-version-file: '.node-version'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 

--- a/.github/workflows/update-openapi-spec.yml
+++ b/.github/workflows/update-openapi-spec.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '24.x'
+          node-version-file: '.node-version'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

Replaces hardcoded `node-version` values in all `actions/setup-node` steps with `node-version-file: '.node-version'`, so CI always builds/tests against the same Node version pinned for local development (currently 20.20.2).

## Changes

- `_test.yml`, `ci-cd.yml`, `release-please.yml`, `update-openapi-spec.yml`, `_codeql.yml`: use `.node-version` instead of hardcoded versions
- `unit-test`/`e2e-test` matrix (previously 18.x/20.x) collapsed to a single run using `.node-version`
- `publish-sdk`/`publish-cli` jobs (previously pinned to 22.x) now also use `.node-version`
