### PR TITLE
fix(ci): use _test.yml reusable workflow for release gate

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,10 +29,10 @@ jobs:
 
   gate:
     permissions:
-      contents: write
+      contents: read
     needs: release-please
     if: needs.release-please.outputs.sdk-release-created == 'true' || needs.release-please.outputs.cli-release-created == 'true'
-    uses: ./.github/workflows/ci-cd.yml
+    uses: ./.github/workflows/_test.yml
     secrets: inherit
 
   publish-sdk:


### PR DESCRIPTION
## Problem

The `gate` job in `release-please.yml` calls the full `ci-cd.yml` reusable workflow but only grants it `contents: write` permission:

```yaml
gate:
  permissions:
    contents: write
  uses: ./.github/workflows/ci-cd.yml
  secrets: inherit
```

`ci-cd.yml` includes a `codeql` job that requires `actions: read`, `packages: read`, and `security-events: write`. A caller job cannot grant a reusable workflow more permissions than it has itself, so the `codeql` job fails to initialize when triggered via `gate`.

## Fix

Point `gate` at the new `_test.yml` reusable workflow instead, which only runs the checks relevant to gating a release (typecheck, lint, format, unit tests, e2e tests, coverage) and only requires `contents: read` across all its jobs — no CodeQL, docs build, or Ketryx reporting needed here.

```yaml
gate:
  permissions:
    contents: read
  uses: ./.github/workflows/_test.yml
  secrets: inherit
```

No changesets included — this is a CI-only workflow fix, not a user-facing SDK/CLI change.