### PR TITLE
feat(cli)!: restructure CLI commands into resource-based groups

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -10,48 +10,74 @@ npm install -g @aignostics/cli
 
 ## Usage
 
+All commands accept a global `--environment` option (`production` [default], `staging`, `develop`).
+
 ### Authentication
 
 ```bash
-# Login to the platform
-aignostics-platform login --endpoint https://api.aignostics.com --client-id your-client-id
+# Login to the platform (opens a browser)
+aignostics-platform auth login
+
+# Login using an existing refresh token
+aignostics-platform auth login --refreshToken <token>
+
+# Check authentication status
+aignostics-platform auth status
+
+# Logout and remove the stored token
+aignostics-platform auth logout
 
 # Test API connection
-aignostics-platform test --endpoint https://api.aignostics.com
+aignostics-platform test-api
 ```
 
-### Application Management
+### Application Discovery
 
 ```bash
 # List applications
-aignostics-platform applications list --endpoint https://api.aignostics.com
+aignostics-platform applications list
 
-# List application versions
-aignostics-platform applications versions --endpoint https://api.aignostics.com --application-id app-id
+# Get details for a specific application
+aignostics-platform applications get <applicationId>
 
-# List application runs
-aignostics-platform applications runs list --endpoint https://api.aignostics.com
+# List versions of an application
+aignostics-platform applications versions list <applicationId>
+
+# Get details of a specific application version
+aignostics-platform applications versions get <applicationId> <versionNumber>
 ```
 
 ### Run Management
 
 ```bash
+# Create a new application run, with items provided inline...
+aignostics-platform runs create <applicationId> <versionNumber> --items '[{"wsi_id": "wsi-123"}]'
+
+# ...from a file...
+aignostics-platform runs create <applicationId> <versionNumber> --items-file ./items.json
+
+# ...or piped via stdin
+cat items.json | aignostics-platform runs create <applicationId> <versionNumber>
+
+# List application runs, optionally filtered/sorted
+aignostics-platform runs list --applicationId <applicationId> --sort '-submitted_at'
+
 # Get run details
-aignostics-platform runs get --endpoint https://api.aignostics.com --run-id run-id
+aignostics-platform runs get <applicationRunId>
 
 # Cancel a run
-aignostics-platform runs cancel --endpoint https://api.aignostics.com --run-id run-id
+aignostics-platform runs cancel <applicationRunId>
 
 # List run results
-aignostics-platform runs results --endpoint https://api.aignostics.com --run-id run-id
+aignostics-platform runs results list <applicationRunId>
 ```
 
 ## Commands
 
 - `info` - Display CLI version information
-- `login` - Authenticate with the platform
-- `test` - Test API connection
-- `applications` - Manage applications
-- `runs` - Manage application runs
+- `test-api` - Test API connection
+- `auth` - `login`, `logout`, `status`
+- `applications` - `list`, `get`, `versions list`, `versions get`
+- `runs` - `create`, `list`, `get`, `cancel`, `results list`
 
 For detailed usage information, use `aignostics-platform --help` or `aignostics-platform <command> --help`.

--- a/packages/cli/e2e/features/TC-application-discovery.feature
+++ b/packages/cli/e2e/features/TC-application-discovery.feature
@@ -9,7 +9,7 @@ Feature: Application Discovery
   @id:TC-APP-LIST
   @tests:SWR-APP-DISCOVERY-LIST
   Scenario: Retrieve all available applications
-    When I run the CLI command "list-applications"
+    When I run the CLI command "applications list"
     Then the exit code should be 0
     And I should see "Applications:" in the output
     And the output should contain a valid JSON array of applications
@@ -19,7 +19,7 @@ Feature: Application Discovery
   @id:TC-APP-DETAILS
   @tests:SWR-APP-DISCOVERY-VERSION-DETAILS
   Scenario: View application details including regulatory information
-    When I run the CLI command "list-applications"
+    When I run the CLI command "applications list"
     Then the exit code should be 0
     And the output should contain application "test-app"
     And application "test-app" should have property "application_id" with value "test-app"
@@ -31,7 +31,7 @@ Feature: Application Discovery
   @tests:SWR-APP-DISCOVERY-VERSION-LIST
   @tests:SWR-APP-DISCOVERY-DETAILS
   Scenario: Retrieve all versions for a specific application
-    When I run the CLI command "list-application-versions test-app"
+    When I run the CLI command "applications versions list test-app"
     Then the exit code should be 0
     And I should see "Application versions for test-app:" in the output
     And the output should contain a valid JSON array of versions
@@ -41,7 +41,7 @@ Feature: Application Discovery
   @id:TC-VERSION-LIST-NOT-FOUND
   @tests:SWR-APP-DISCOVERY-VERSION-LIST
   Scenario: Handle error when listing versions for non-existent application
-    When I run the CLI command "list-application-versions non-existent-app"
+    When I run the CLI command "applications versions list non-existent-app"
     Then I should see "API_ERROR" in stderr
     And I should see "application not found" in stderr
     And the exit code should not be 0
@@ -49,7 +49,7 @@ Feature: Application Discovery
   @id:TC-VERSION-DETAILS
   @tests:SWR-APP-DISCOVERY-VERSION-DETAILS
   Scenario: View specific application version details
-    When I run the CLI command "get-application-version-details test-app 1.0.0"
+    When I run the CLI command "applications versions get test-app 1.0.0"
     Then the exit code should be 0
     And I should see "Application version details for test-app v1.0.0:" in the output
     And the output should contain a JSON object with "version_number" equal to "1.0.0"
@@ -60,7 +60,7 @@ Feature: Application Discovery
   @tests:SWR-ERROR-COMM-DIAGNOSTIC-CONTEXT
   @tests:SWR-ERROR-COMM-CLASSIFICATION
   Scenario: Handle error when requesting non-existent version details
-    When I run the CLI command "get-application-version-details test-app 2.0.0"
+    When I run the CLI command "applications versions get test-app 2.0.0"
     Then I should see "API_ERROR" in stderr
     And I should see "Application version not found" in stderr
     And the exit code should not be 0

--- a/packages/cli/e2e/features/TC-application-execution.feature
+++ b/packages/cli/e2e/features/TC-application-execution.feature
@@ -12,7 +12,7 @@ Feature: Application Execution
   @tests:SWR-APP-EXEC-INPUT-ARTIFACT
   Scenario: Create application run with valid input items
     Given I have 2 valid input artifacts for "test-app" version "1.0.0"
-    When I run the CLI command "create-run test-app 1.0.0 --items <items_json>"
+    When I run the CLI command "runs create test-app 1.0.0 --items <items_json>"
     Then the exit code should be 0
     And I should see "Application run created successfully:" in the output
     And the output should contain a JSON object with property "run_id"
@@ -22,7 +22,7 @@ Feature: Application Execution
   @tests:SWR-ERROR-COMM-CLI-OUTPUT
   Scenario: Handle error when creating run with non-existent version
     Given I have 2 valid input artifacts for "test-app" version "1.0.0"
-    When I run the CLI command "create-run test-app 2.0.0 --items <items_json>"
+    When I run the CLI command "runs create test-app 2.0.0 --items <items_json>"
     Then I should see "API_ERROR" in stderr
     And I should see "application version not found" in stderr
     And the exit code should not be 0
@@ -30,7 +30,7 @@ Feature: Application Execution
   @id:TC-RUN-CREATE-MISSING-ARGS
   @tests:SWR-ERROR-COMM-MESSAGES
   Scenario: Handle error when creating run with missing arguments
-    When I run the CLI command "create-run"
+    When I run the CLI command "runs create"
     Then I should see "Not enough non-option arguments: got 0, need at least 2" in stderr
     And the exit code should not be 0
 
@@ -38,6 +38,6 @@ Feature: Application Execution
   @tests:SWR-APP-EXEC-REQUEST-VALIDATION
   @tests:SWR-ERROR-COMM-MESSAGES
   Scenario: Validate items JSON before submission
-    When I run the CLI command "create-run test-app 1.0.0 --items invalid-json"
+    When I run the CLI command "runs create test-app 1.0.0 --items invalid-json"
     Then I should see "Invalid items JSON:" in stderr
     And the exit code should not be 0

--- a/packages/cli/e2e/features/TC-application-results-access.feature
+++ b/packages/cli/e2e/features/TC-application-results-access.feature
@@ -12,7 +12,7 @@ Feature: Application Results Access
   Scenario: Retrieve items and output artifacts for a run
     Given I have a list of runs for "test-app" version "1.0.0"
     And I select the latest run ID from the list
-    When I run the CLI command "list-run-results <run_id>"
+    When I run the CLI command "runs results list <run_id>"
     Then the exit code should be 0
     And I should see "Run results for <run_id>:" in the output
     And the output should contain a valid JSON array of run results
@@ -23,7 +23,7 @@ Feature: Application Results Access
   Scenario: View execution state and status details for items
     Given I have a list of runs for "test-app" version "1.0.0"
     And I select the latest run ID from the list
-    When I run the CLI command "list-run-results <run_id>"
+    When I run the CLI command "runs results list <run_id>"
     Then the exit code should be 0
     And each result should have property "state"
     And each result should have property "termination_reason"
@@ -37,7 +37,7 @@ Feature: Application Results Access
   @tests:SWR-ERROR-COMM-MESSAGES
   @tests:SWR-ERROR-COMM-CLI-OUTPUT
   Scenario: Handle error when requesting results with invalid run ID
-    When I run the CLI command "list-run-results non-existent-run-id"
+    When I run the CLI command "runs results list non-existent-run-id"
     Then I should see "API_ERROR" in stderr
     And I should see "Validation error" in stderr
     And the exit code should not be 0

--- a/packages/cli/e2e/features/TC-application-run-management.feature
+++ b/packages/cli/e2e/features/TC-application-run-management.feature
@@ -10,7 +10,7 @@ Feature: Application Run Management
   @id:TC-RUN-LIST
   @tests:SWR-APP-RUN-MGMT-LIST
   Scenario: List application runs with filtering
-    When I run the CLI command "list-application-runs --applicationId test-app --applicationVersion 1.0.0"
+    When I run the CLI command "runs list --applicationId test-app --applicationVersion 1.0.0"
     Then the exit code should be 0
     And I should see "Application runs:" in the output
     And the output should contain a valid JSON array of runs
@@ -21,7 +21,7 @@ Feature: Application Run Management
   Scenario: Retrieve detailed information for a specific run
     Given I have a list of runs for "test-app" version "1.0.0"
     And I select the latest run ID from the list
-    When I run the CLI command "get-run <run_id>"
+    When I run the CLI command "runs get <run_id>"
     Then the exit code should be 0
     And I should see "Run details for <run_id>:" in the output
     And the output should contain a JSON object with "run_id" equal to "<run_id>"
@@ -32,6 +32,6 @@ Feature: Application Run Management
   Scenario: Cancel a pending application run
     Given I have a list of runs for "test-app" version "1.0.0"
     And there is a run with state "PENDING"
-    When I run the CLI command "cancel-run <pending_run_id>"
+    When I run the CLI command "runs cancel <pending_run_id>"
     Then the exit code should be 0
     And I should see "Successfully cancelled application run: <pending_run_id>" in the output

--- a/packages/cli/e2e/specs/1-Authentication.e2e.test.ts
+++ b/packages/cli/e2e/specs/1-Authentication.e2e.test.ts
@@ -65,7 +65,7 @@ describe('Authentication', () => {
       try {
         let authUrl = '';
 
-        const cliPromise = executeCLI(['login']);
+        const cliPromise = executeCLI(['auth', 'login']);
 
         const dataHandler = (data: Buffer) => {
           const output = String(data);
@@ -160,7 +160,12 @@ describe('Authentication', () => {
     await annotate('SWR-AUTH-SECURE-STORAGE', 'tests');
     await annotate('TC-AUTH-TOKEN', 'id');
 
-    const { stdout: loginStdout } = await executeCLI(['login', '--refreshToken', refreshToken]);
+    const { stdout: loginStdout } = await executeCLI([
+      'auth',
+      'login',
+      '--refreshToken',
+      refreshToken,
+    ]);
     expect(loginStdout).toContain('🎉 Login with refresh token successful! Token saved securely.');
 
     const { stdout: testApiStdout } = await executeCLI(['test-api']);
@@ -208,7 +213,7 @@ describe('Authentication', () => {
 
     const data = await tokenStorage.load(environment);
 
-    await executeCLI(['logout'], { reject: false });
+    await executeCLI(['auth', 'logout'], { reject: false });
 
     const { stderr: testApiStderr } = await executeCLI(['test-api'], { reject: false });
 

--- a/packages/cli/e2e/specs/2-Application Discovery.e2e.test.ts
+++ b/packages/cli/e2e/specs/2-Application Discovery.e2e.test.ts
@@ -23,7 +23,7 @@ describe('SWR Application List Retrieval', () => {
     await annotate('SWR-APP-DISCOVERY-LIST', 'tests');
     await annotate('TC-APP-LIST', 'id');
 
-    const { stdout, exitCode } = await executeCLI(['list-applications']);
+    const { stdout, exitCode } = await executeCLI(['applications', 'list']);
 
     expect(exitCode).toBe(0);
 
@@ -44,7 +44,7 @@ describe('SWR Application Details', () => {
     await annotate('SWR-APP-DISCOVERY-VERSION-DETAILS', 'tests');
     await annotate('TC-APP-DETAILS', 'id');
 
-    const { stdout, exitCode } = await executeCLI(['list-applications']);
+    const { stdout, exitCode } = await executeCLI(['applications', 'list']);
 
     expect(exitCode).toBe(0);
 
@@ -76,7 +76,7 @@ describe('SWR Version List Retrieval', () => {
     await annotate('SWR-APP-DISCOVERY-DETAILS', 'tests');
     await annotate('TC-VERSION-LIST', 'id');
 
-    const { stdout, exitCode } = await executeCLI(['list-application-versions', 'test-app']);
+    const { stdout, exitCode } = await executeCLI(['applications', 'versions', 'list', 'test-app']);
 
     expect(exitCode).toBe(0);
 
@@ -103,7 +103,7 @@ describe('SWR Version List Retrieval', () => {
   it('should return an error when the app does not exist', async ({ annotate }) => {
     await annotate('TC-VERSION-LIST-NOT-FOUND', 'id');
 
-    const { stderr } = await executeCLI(['list-application-versions', 'non-existent-app'], {
+    const { stderr } = await executeCLI(['applications', 'versions', 'list', 'non-existent-app'], {
       reject: false,
     });
 
@@ -118,7 +118,9 @@ describe('SWR Specific Version Details', () => {
     await annotate('TC-VERSION-DETAILS', 'id');
 
     const { stdout, exitCode } = await executeCLI([
-      'get-application-version-details',
+      'applications',
+      'versions',
+      'get',
       'test-app',
       '1.0.0',
     ]);
@@ -144,7 +146,7 @@ describe('SWR Specific Version Details', () => {
     await annotate('SWR-ERROR-COMM-CLASSIFICATION', 'tests');
     await annotate('TC-VERSION-DETAILS-NOT-FOUND', 'id');
 
-    const { stderr } = await executeCLI(['get-application-version-details', 'test-app', '2.0.0'], {
+    const { stderr } = await executeCLI(['applications', 'versions', 'get', 'test-app', '2.0.0'], {
       reject: false,
     });
     expect(stderr).toMatch(/API_ERROR/);

--- a/packages/cli/e2e/specs/3-Application-execution.e2e.test.ts
+++ b/packages/cli/e2e/specs/3-Application-execution.e2e.test.ts
@@ -16,7 +16,8 @@ describe('SWR Application Execution access', async () => {
     const items = await generateInputArtifactsForTest('test-app', latestVersion, 2);
 
     const { stdout, exitCode } = await executeCLI([
-      'create-run',
+      'runs',
+      'create',
       'test-app',
       '1.0.0',
       '--items',
@@ -42,7 +43,7 @@ describe('SWR Application Execution access', async () => {
     const items = await generateInputArtifactsForTest('test-app', latestVersion, 2);
 
     const { stderr, exitCode } = await executeCLI(
-      ['create-run', 'test-app', '2.0.0', '--items', JSON.stringify(items)],
+      ['runs', 'create', 'test-app', '2.0.0', '--items', JSON.stringify(items)],
       { reject: false }
     );
 
@@ -58,7 +59,7 @@ describe('SWR Application Execution access', async () => {
     await annotate('SWR-ERROR-COMM-MESSAGES', 'tests');
     await annotate('TC-RUN-CREATE-MISSING-ARGS', 'id');
 
-    const { stderr } = await executeCLI(['create-run'], { reject: false });
+    const { stderr } = await executeCLI(['runs', 'create'], { reject: false });
     expect(stderr).toContain('❌ Not enough non-option arguments: got 0, need at least 2');
   });
 
@@ -68,7 +69,7 @@ describe('SWR Application Execution access', async () => {
     await annotate('TC-RUN-CREATE-INVALID-JSON', 'id');
 
     const { stderr } = await executeCLI(
-      ['create-run', 'test-app', latestVersion, '--items', 'invalid-json'],
+      ['runs', 'create', 'test-app', latestVersion, '--items', 'invalid-json'],
       { reject: false }
     );
     expect(stderr).toContain('❌ Invalid items JSON:');

--- a/packages/cli/e2e/specs/4-Applicatioin-run-management.e2e.test.ts
+++ b/packages/cli/e2e/specs/4-Applicatioin-run-management.e2e.test.ts
@@ -10,7 +10,8 @@ describe('SWR Application Run management', () => {
     await annotate('TC-RUN-LIST', 'id');
 
     const { stdout, exitCode } = await executeCLI([
-      'list-application-runs',
+      'runs',
+      'list',
       '--applicationId',
       'test-app',
       '--applicationVersion',
@@ -35,7 +36,8 @@ describe('SWR Application Run management', () => {
     await annotate('TC-RUN-DETAILS', 'id');
 
     const { stdout, exitCode } = await executeCLI([
-      'list-application-runs',
+      'runs',
+      'list',
       '--applicationId',
       'test-app',
       '--applicationVersion',
@@ -49,7 +51,8 @@ describe('SWR Application Run management', () => {
     const latestRunId = runs[0].run_id;
 
     const { stdout: runDetailsStdout, exitCode: runDetailsExitCode } = await executeCLI([
-      'get-run',
+      'runs',
+      'get',
       latestRunId,
     ]);
 
@@ -70,7 +73,8 @@ describe('SWR Application Run management', () => {
     await annotate('TC-RUN-CANCEL', 'id');
 
     const { stdout, exitCode } = await executeCLI([
-      'list-application-runs',
+      'runs',
+      'list',
       '--applicationId',
       'test-app',
       '--applicationVersion',
@@ -84,11 +88,12 @@ describe('SWR Application Run management', () => {
     const pendingRunId = runs.find(run => run.state === 'PENDING')?.run_id;
 
     if (!pendingRunId) {
-      console.warn('No PENDING runs found to cancel. Skipping cancel-run test.');
+      console.warn('No PENDING runs found to cancel. Skipping runs cancel test.');
       return;
     }
     const { stdout: cancelRunStdout, exitCode: cancelRunExitCode } = await executeCLI([
-      'cancel-run',
+      'runs',
+      'cancel',
       pendingRunId,
     ]);
 

--- a/packages/cli/e2e/specs/5-Application-results-access.e2e.test.ts
+++ b/packages/cli/e2e/specs/5-Application-results-access.e2e.test.ts
@@ -10,7 +10,8 @@ describe('Application Results Access', () => {
     await annotate('TC-RESULTS-RETRIEVE', 'id');
 
     const { stdout, exitCode } = await executeCLI([
-      'list-application-runs',
+      'runs',
+      'list',
       '--applicationId',
       'test-app',
       '--applicationVersion',
@@ -24,7 +25,9 @@ describe('Application Results Access', () => {
     const latestRunId = runs[0].run_id;
 
     const { stdout: runResultsStdout, exitCode: runResultsExitCode } = await executeCLI([
-      'list-run-results',
+      'runs',
+      'results',
+      'list',
       latestRunId,
     ]);
 
@@ -47,7 +50,8 @@ describe('Application Results Access', () => {
     await annotate('TC-RESULTS-STATUS', 'id');
 
     const { stdout, exitCode } = await executeCLI([
-      'list-application-runs',
+      'runs',
+      'list',
       '--applicationId',
       'test-app',
       '--applicationVersion',
@@ -61,7 +65,9 @@ describe('Application Results Access', () => {
     const latestRunId = runs[0].run_id;
 
     const { stdout: runResultsStdout, exitCode: runResultsExitCode } = await executeCLI([
-      'list-run-results',
+      'runs',
+      'results',
+      'list',
       latestRunId,
     ]);
 
@@ -95,9 +101,12 @@ describe('Application Results Access', () => {
     await annotate('SWR-ERROR-COMM-CLI-OUTPUT', 'tests');
     await annotate('TC-RESULTS-INVALID-UUID', 'id');
 
-    const { stderr, exitCode } = await executeCLI(['list-run-results', 'non-existent-run-id'], {
-      reject: false,
-    });
+    const { stderr, exitCode } = await executeCLI(
+      ['runs', 'results', 'list', 'non-existent-run-id'],
+      {
+        reject: false,
+      }
+    );
 
     // Verify error written to stderr
     expect(stderr).toMatch(/API_ERROR/);

--- a/packages/cli/e2e/utils/getAppInputArtifacts.ts
+++ b/packages/cli/e2e/utils/getAppInputArtifacts.ts
@@ -188,7 +188,7 @@ const generateMetadataFromSchema = (
 };
 
 export const getAppInputArtifacts = async (applicationId: string, version: string) => {
-  const { stdout } = await executeCLI(['get-application-version-details', applicationId, version]);
+  const { stdout } = await executeCLI(['applications', 'versions', 'get', applicationId, version]);
 
   // Match the JSON object after the prefix
   const detailsMatch = String(stdout).match(

--- a/packages/cli/e2e/utils/getAppLatestVersion.ts
+++ b/packages/cli/e2e/utils/getAppLatestVersion.ts
@@ -2,7 +2,7 @@ import { ApplicationVersion } from '@aignostics/sdk';
 import { executeCLI } from './command.js';
 
 export const getAppLatestVersion = async (applicationId: string) => {
-  const { stdout } = await executeCLI(['list-application-versions', applicationId]);
+  const { stdout } = await executeCLI(['applications', 'versions', 'list', applicationId]);
 
   // Parse the versions from the output
   const output = String(stdout);

--- a/packages/cli/e2e/vitest.global-setup.ts
+++ b/packages/cli/e2e/vitest.global-setup.ts
@@ -8,12 +8,12 @@ export async function setup() {
   }
 
   console.log('🔐 Logging in...');
-  await executeCLI(['login', '--refreshToken', refreshToken]);
+  await executeCLI(['auth', 'login', '--refreshToken', refreshToken]);
   console.log('✅ Logged in.');
 
   return async () => {
     console.log('🔓 Logging out...');
-    await executeCLI(['logout']);
+    await executeCLI(['auth', 'logout']);
     console.log('✅ Logged out.');
   };
 }

--- a/packages/cli/src/cli-functions.spec.ts
+++ b/packages/cli/src/cli-functions.spec.ts
@@ -1,16 +1,18 @@
 /* eslint-disable @typescript-eslint/unbound-method */
-import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
 import {
   handleInfo,
   testApi,
   listApplications,
   getApplicationVersionDetails,
+  getApplicationDetails,
   listApplicationVersions,
   listApplicationRuns,
   getRun,
   cancelApplicationRun,
   listRunResults,
   createApplicationRun,
+  resolveItemsInput,
   handleLogin,
   handleLogout,
   handleStatus,
@@ -20,6 +22,10 @@ import { PlatformSDK, PlatformSDKHttp } from '@aignostics/sdk';
 import { AuthService, AuthState } from './utils/auth.js';
 import { startCallbackServer, waitForCallback } from './utils/oauth-callback-server.js';
 import crypto from 'crypto';
+import * as fs from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { Readable } from 'stream';
 import { EnvironmentKey } from './utils/environment.js';
 
 // Mock external dependencies
@@ -212,6 +218,37 @@ describe('CLI Functions Unit Tests', () => {
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
         '❌ Failed to get application version details:',
+        expect.any(Error)
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('getApplicationDetails', () => {
+    it('should get application details successfully', async () => {
+      const applicationResponse = {
+        application_id: 'app1',
+        name: 'Test Application',
+        versions: [{ version_number: 'v1.0.0', created_at: '2023-01-01T00:00:00Z' }],
+      };
+      platformSDKMock.getApplication.mockResolvedValue(applicationResponse);
+
+      await getApplicationDetails('production', mockAuthService, 'app1');
+
+      expect(platformSDKMock.getApplication).toHaveBeenCalledWith('app1');
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        'Application details for app1:',
+        JSON.stringify(applicationResponse, null, 2)
+      );
+    });
+
+    it('should handle API error', async () => {
+      platformSDKMock.getApplication.mockRejectedValue(new Error('API error'));
+
+      await getApplicationDetails('production', mockAuthService, 'app1');
+
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        '❌ Failed to get application details:',
         expect.any(Error)
       );
       expect(mockExit).toHaveBeenCalledWith(1);
@@ -566,6 +603,72 @@ describe('CLI Functions Unit Tests', () => {
         expect.any(Error)
       );
       expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('resolveItemsInput', () => {
+    let originalIsTTY: boolean | undefined;
+
+    beforeEach(() => {
+      originalIsTTY = process.stdin.isTTY;
+      process.stdin.isTTY = true;
+    });
+
+    afterEach(() => {
+      process.stdin.isTTY = originalIsTTY;
+    });
+
+    it('should prefer the inline items option', async () => {
+      const result = await resolveItemsInput({ items: '[{"a":1}]', itemsFile: '/tmp/items.json' });
+
+      expect(result).toBe('[{"a":1}]');
+    });
+
+    it('should read from the items file when no inline items are given', async () => {
+      const itemsFile = join(tmpdir(), `resolve-items-input-${Date.now()}.json`);
+      fs.writeFileSync(itemsFile, '[{"b":2}]');
+
+      try {
+        const result = await resolveItemsInput({ itemsFile });
+
+        expect(result).toBe('[{"b":2}]');
+      } finally {
+        fs.unlinkSync(itemsFile);
+      }
+    });
+
+    it('should default to an empty array when running interactively with no options', async () => {
+      const result = await resolveItemsInput({});
+
+      expect(result).toBe('[]');
+    });
+
+    it('should read items piped via stdin when no options are given', async () => {
+      const stdinStream = Readable.from([
+        Buffer.from('[{"c":3}]'),
+      ]) as unknown as typeof process.stdin;
+      stdinStream.isTTY = false;
+      const originalStdin = process.stdin;
+      process.stdin = stdinStream;
+
+      const result = await resolveItemsInput({});
+
+      expect(result).toBe('[{"c":3}]');
+
+      process.stdin = originalStdin;
+    });
+
+    it('should default to an empty array when stdin is piped but empty', async () => {
+      const stdinStream = Readable.from([]) as unknown as typeof process.stdin;
+      stdinStream.isTTY = false;
+      const originalStdin = process.stdin;
+      process.stdin = stdinStream;
+
+      const result = await resolveItemsInput({});
+
+      expect(result).toBe('[]');
+
+      process.stdin = originalStdin;
     });
   });
 

--- a/packages/cli/src/cli-functions.ts
+++ b/packages/cli/src/cli-functions.ts
@@ -73,6 +73,25 @@ export async function getApplicationVersionDetails(
   }
 }
 
+export async function getApplicationDetails(
+  environment: EnvironmentKey,
+  authService: AuthService,
+  applicationId: string
+): Promise<void> {
+  const { endpoint } = environmentConfig[environment];
+  const sdk = new PlatformSDKHttp({
+    baseURL: endpoint,
+    tokenProvider: () => authService.getValidAccessToken(environment),
+  });
+  try {
+    const response = await sdk.getApplication(applicationId);
+    console.log(`Application details for ${applicationId}:`, JSON.stringify(response, null, 2));
+  } catch (error) {
+    console.error('❌ Failed to get application details:', error);
+    process.exit(1);
+  }
+}
+
 export async function listApplicationVersions(
   environment: EnvironmentKey,
   authService: AuthService,
@@ -187,6 +206,37 @@ export async function listRunResults(
     console.error('❌ Failed to list run results:', error);
     process.exit(1);
   }
+}
+
+/**
+ * Resolve the JSON string of items to submit for a run, from (in order of precedence):
+ * an inline `--items` value, an `--items-file` path, or piped stdin. Falls back to an
+ * empty array when none of these provide data.
+ */
+export async function resolveItemsInput(options: {
+  items?: string;
+  itemsFile?: string;
+}): Promise<string> {
+  if (options.items !== undefined) {
+    return options.items;
+  }
+
+  if (options.itemsFile !== undefined) {
+    return readFileSync(options.itemsFile, 'utf-8');
+  }
+
+  if (!process.stdin.isTTY) {
+    const chunks: Buffer[] = [];
+    for await (const chunk of process.stdin) {
+      chunks.push(chunk as Buffer);
+    }
+    const data = Buffer.concat(chunks).toString('utf-8').trim();
+    if (data) {
+      return data;
+    }
+  }
+
+  return '[]';
 }
 
 export async function createApplicationRun(

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -3,6 +3,7 @@ import { main } from './cli.js';
 import { factories, handlers, server } from '@aignostics/sdk/test';
 import { http, HttpResponse } from 'msw';
 import { ZodError } from 'zod';
+import { Readable } from 'stream';
 
 // Mock process.exit to prevent test runner from exiting
 const mockExit = vi.fn();
@@ -54,10 +55,18 @@ describe('CLI Integration Tests', () => {
   };
 
   let originalArgv: string[];
+  let originalStdin: typeof process.stdin;
+  let originalStdinIsTTY: boolean | undefined;
 
   beforeEach(() => {
     // Store original argv
     originalArgv = process.argv;
+
+    // Simulate an interactive terminal by default so `runs create` doesn't
+    // try to read items from stdin (which would otherwise hang in tests).
+    originalStdin = process.stdin;
+    originalStdinIsTTY = process.stdin.isTTY;
+    process.stdin.isTTY = true;
 
     server.use(...handlers.success);
 
@@ -69,6 +78,10 @@ describe('CLI Integration Tests', () => {
   });
 
   afterEach(() => {
+    // Restore stdin
+    process.stdin = originalStdin;
+    process.stdin.isTTY = originalStdinIsTTY;
+
     // Restore original argv
     process.argv = originalArgv;
   });
@@ -96,13 +109,14 @@ describe('CLI Integration Tests', () => {
     });
   });
 
-  describe('list-applications command', () => {
+  describe('applications list command', () => {
     it('should list applications successfully', async () => {
       // Mock process.argv for yargs
       process.argv = [
         'node',
         'cli.js',
-        'list-applications',
+        'applications',
+        'list',
         '--endpoint',
         'https://api.example.com',
       ];
@@ -117,7 +131,55 @@ describe('CLI Integration Tests', () => {
     });
   });
 
-  describe('list-application-versions command', () => {
+  describe('applications get command', () => {
+    it('should get application details successfully', async () => {
+      const application = factories.application.build();
+      server.use(
+        http.get('*/v1/applications/:applicationId', () =>
+          HttpResponse.json(application, { status: 200 })
+        )
+      );
+      process.argv = [
+        'node',
+        'cli.js',
+        'applications',
+        'get',
+        application.application_id,
+        '--endpoint',
+        'https://api.example.com',
+      ];
+
+      await main();
+
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        `Application details for ${application.application_id}:`,
+        expect.stringContaining(application.application_id)
+      );
+    });
+
+    it('should print error responses', async () => {
+      const application = factories.application.build();
+      server.use(http.get('*/v1/applications/:applicationId', () => HttpResponse.error()));
+      process.argv = [
+        'node',
+        'cli.js',
+        'applications',
+        'get',
+        application.application_id,
+        '--endpoint',
+        'https://api.example.com',
+      ];
+
+      await main();
+
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        expect.stringContaining('❌ Failed to get application details:'),
+        expect.any(Error)
+      );
+    });
+  });
+
+  describe('applications versions list command', () => {
     it('should list application versions successfully', async () => {
       const application = factories.application.build();
       server.use(
@@ -129,7 +191,9 @@ describe('CLI Integration Tests', () => {
       process.argv = [
         'node',
         'cli.js',
-        'list-application-versions',
+        'applications',
+        'versions',
+        'list',
         application.application_id,
         '--endpoint',
         'https://api.example.com',
@@ -154,7 +218,9 @@ describe('CLI Integration Tests', () => {
       process.argv = [
         'node',
         'cli.js',
-        'list-application-versions',
+        'applications',
+        'versions',
+        'list',
         application.application_id,
         '--endpoint',
         'https://api.example.com',
@@ -169,7 +235,7 @@ describe('CLI Integration Tests', () => {
     });
   });
 
-  describe('get-application-version-details command', () => {
+  describe('applications versions get command', () => {
     it('should get application version details successfully', async () => {
       const application = factories.application.build();
       const version = application.versions[0];
@@ -183,7 +249,9 @@ describe('CLI Integration Tests', () => {
       process.argv = [
         'node',
         'cli.js',
-        'get-application-version-details',
+        'applications',
+        'versions',
+        'get',
         application.application_id,
         version.number,
         '--endpoint',
@@ -211,7 +279,9 @@ describe('CLI Integration Tests', () => {
       process.argv = [
         'node',
         'cli.js',
-        'get-application-version-details',
+        'applications',
+        'versions',
+        'get',
         application.application_id,
         version.number,
         '--endpoint',
@@ -227,7 +297,7 @@ describe('CLI Integration Tests', () => {
     });
 
     it('should require applicationId and versionNumber parameters', async () => {
-      process.argv = ['node', 'cli.js', 'get-application-version-details'];
+      process.argv = ['node', 'cli.js', 'applications', 'versions', 'get'];
 
       await main();
 
@@ -237,16 +307,10 @@ describe('CLI Integration Tests', () => {
     });
   });
 
-  describe('list-application-runs command', () => {
+  describe('runs list command', () => {
     it('should list application runs successfully', async () => {
       // Mock process.argv for yargs
-      process.argv = [
-        'node',
-        'cli.js',
-        'list-application-runs',
-        '--endpoint',
-        'https://api.example.com',
-      ];
+      process.argv = ['node', 'cli.js', 'runs', 'list', '--endpoint', 'https://api.example.com'];
 
       await main();
 
@@ -265,7 +329,8 @@ describe('CLI Integration Tests', () => {
       process.argv = [
         'node',
         'cli.js',
-        'list-application-runs',
+        'runs',
+        'list',
         '--applicationId',
         'app1',
         '--endpoint',
@@ -285,7 +350,8 @@ describe('CLI Integration Tests', () => {
       process.argv = [
         'node',
         'cli.js',
-        'list-application-runs',
+        'runs',
+        'list',
         '--applicationVersion',
         'v1.0.0',
         '--endpoint',
@@ -301,13 +367,14 @@ describe('CLI Integration Tests', () => {
     });
   });
 
-  describe('get-run command', () => {
+  describe('runs get command', () => {
     it('should get run details successfully', async () => {
       // Mock process.argv for yargs
       process.argv = [
         'node',
         'cli.js',
-        'get-run',
+        'runs',
+        'get',
         'run-1',
         '--endpoint',
         'https://api.example.com',
@@ -327,7 +394,7 @@ describe('CLI Integration Tests', () => {
 
     it('should require applicationRunId parameter', async () => {
       // Mock process.argv for yargs - missing applicationRunId
-      process.argv = ['node', 'cli.js', 'get-run'];
+      process.argv = ['node', 'cli.js', 'runs', 'get'];
 
       await main();
       expect(consoleSpy.error).toHaveBeenCalledWith(
@@ -336,13 +403,14 @@ describe('CLI Integration Tests', () => {
     });
   });
 
-  describe('cancel-run command', () => {
+  describe('runs cancel command', () => {
     it('should cancel run successfully', async () => {
       // Mock process.argv for yargs
       process.argv = [
         'node',
         'cli.js',
-        'cancel-run',
+        'runs',
+        'cancel',
         'run-1',
         '--endpoint',
         'https://api.example.com',
@@ -357,7 +425,7 @@ describe('CLI Integration Tests', () => {
 
     it('should require applicationRunId parameter', async () => {
       // Mock process.argv for yargs - missing applicationRunId
-      process.argv = ['node', 'cli.js', 'cancel-run'];
+      process.argv = ['node', 'cli.js', 'runs', 'cancel'];
 
       await main();
       expect(consoleSpy.error).toHaveBeenCalledWith(
@@ -366,13 +434,15 @@ describe('CLI Integration Tests', () => {
     });
   });
 
-  describe('list-run-results command', () => {
+  describe('runs results list command', () => {
     it('should list run results successfully', async () => {
       // Mock process.argv for yargs
       process.argv = [
         'node',
         'cli.js',
-        'list-run-results',
+        'runs',
+        'results',
+        'list',
         'run-1',
         '--endpoint',
         'https://api.example.com',
@@ -392,7 +462,7 @@ describe('CLI Integration Tests', () => {
 
     it('should require applicationRunId parameter', async () => {
       // Mock process.argv for yargs - missing applicationRunId
-      process.argv = ['node', 'cli.js', 'list-run-results'];
+      process.argv = ['node', 'cli.js', 'runs', 'results', 'list'];
 
       await main();
 
@@ -402,14 +472,16 @@ describe('CLI Integration Tests', () => {
     });
   });
 
-  describe('create-run command', () => {
+  describe('runs create command', () => {
     it('should create application run successfully with empty items', async () => {
       // Mock process.argv for yargs
       process.argv = [
         'node',
         'cli.js',
-        'create-run',
-        'test-app:v1.0.0',
+        'runs',
+        'create',
+        'test-app',
+        'v1.0.0',
         '--endpoint',
         'https://api.example.com',
         '--items',
@@ -429,8 +501,10 @@ describe('CLI Integration Tests', () => {
       process.argv = [
         'node',
         'cli.js',
-        'create-run',
-        'test-app:v1.0.0',
+        'runs',
+        'create',
+        'test-app',
+        'v1.0.0',
         '--endpoint',
         'https://api.example.com',
       ];
@@ -443,9 +517,9 @@ describe('CLI Integration Tests', () => {
       );
     });
 
-    it('should require applicationVersionId parameter', async () => {
-      // Mock process.argv for yargs - missing applicationVersionId
-      process.argv = ['node', 'cli.js', 'create-run'];
+    it('should require applicationId and versionNumber parameters', async () => {
+      // Mock process.argv for yargs - missing applicationId and versionNumber
+      process.argv = ['node', 'cli.js', 'runs', 'create'];
 
       await main();
       expect(consoleSpy.error).toHaveBeenCalledWith(
@@ -500,13 +574,14 @@ describe('CLI Integration Tests', () => {
     });
   });
 
-  describe('login command', () => {
+  describe('auth login command', () => {
     it('should login with refresh token when --refreshToken is provided', async () => {
       const refreshToken = 'test-refresh-token-12345';
 
       process.argv = [
         'node',
         'cli.js',
+        'auth',
         'login',
         '--refreshToken',
         refreshToken,
@@ -577,9 +652,9 @@ describe('CLI Integration Tests', () => {
     });
   });
 
-  describe('logout command', () => {
+  describe('auth logout command', () => {
     it('should logout successfully', async () => {
-      process.argv = ['node', 'cli.js', 'logout', '--environment', 'production'];
+      process.argv = ['node', 'cli.js', 'auth', 'logout', '--environment', 'production'];
 
       await main();
 
@@ -588,7 +663,7 @@ describe('CLI Integration Tests', () => {
     });
 
     it('should logout from staging environment', async () => {
-      process.argv = ['node', 'cli.js', 'logout', '--environment', 'staging'];
+      process.argv = ['node', 'cli.js', 'auth', 'logout', '--environment', 'staging'];
 
       await main();
 
@@ -597,9 +672,9 @@ describe('CLI Integration Tests', () => {
     });
   });
 
-  describe('status command', () => {
+  describe('auth status command', () => {
     it('should check authentication status successfully', async () => {
-      process.argv = ['node', 'cli.js', 'status', '--environment', 'production'];
+      process.argv = ['node', 'cli.js', 'auth', 'status', '--environment', 'production'];
 
       await main();
 
@@ -608,7 +683,7 @@ describe('CLI Integration Tests', () => {
     });
 
     it('should check status for staging environment', async () => {
-      process.argv = ['node', 'cli.js', 'status', '--environment', 'staging'];
+      process.argv = ['node', 'cli.js', 'auth', 'status', '--environment', 'staging'];
 
       await main();
 
@@ -617,9 +692,9 @@ describe('CLI Integration Tests', () => {
     });
   });
 
-  describe('login command without refresh token', () => {
+  describe('auth login command without refresh token', () => {
     it('should initiate login flow without refresh token', async () => {
-      process.argv = ['node', 'cli.js', 'login', '--environment', 'production'];
+      process.argv = ['node', 'cli.js', 'auth', 'login', '--environment', 'production'];
 
       await main();
 
@@ -628,7 +703,7 @@ describe('CLI Integration Tests', () => {
     });
 
     it('should login with staging environment', async () => {
-      process.argv = ['node', 'cli.js', 'login', '--environment', 'staging'];
+      process.argv = ['node', 'cli.js', 'auth', 'login', '--environment', 'staging'];
 
       await main();
 
@@ -636,9 +711,9 @@ describe('CLI Integration Tests', () => {
     });
   });
 
-  describe('list-application-runs with options', () => {
+  describe('runs list with options', () => {
     it('should support filtering by customMetadata', async () => {
-      process.argv = ['node', 'cli.js', 'list-application-runs', '--customMetadata', '$.key=value'];
+      process.argv = ['node', 'cli.js', 'runs', 'list', '--customMetadata', '$.key=value'];
 
       await main();
 
@@ -649,7 +724,7 @@ describe('CLI Integration Tests', () => {
     });
 
     it('should support sort option', async () => {
-      process.argv = ['node', 'cli.js', 'list-application-runs', '--sort', '["run_id"]'];
+      process.argv = ['node', 'cli.js', 'runs', 'list', '--sort', '["run_id"]'];
 
       await main();
 
@@ -663,7 +738,8 @@ describe('CLI Integration Tests', () => {
       process.argv = [
         'node',
         'cli.js',
-        'list-application-runs',
+        'runs',
+        'list',
         '--applicationId',
         'app1',
         '--applicationVersion',
@@ -681,12 +757,13 @@ describe('CLI Integration Tests', () => {
     });
   });
 
-  describe('create-run with items', () => {
+  describe('runs create with items', () => {
     it('should create application run with items', async () => {
       process.argv = [
         'node',
         'cli.js',
-        'create-run',
+        'runs',
+        'create',
         'test-app',
         'v1.0.0',
         '--items',
@@ -705,7 +782,8 @@ describe('CLI Integration Tests', () => {
       process.argv = [
         'node',
         'cli.js',
-        'create-run',
+        'runs',
+        'create',
         'test-app',
         'v1.0.0',
         '--items',
@@ -722,7 +800,8 @@ describe('CLI Integration Tests', () => {
       process.argv = [
         'node',
         'cli.js',
-        'create-run',
+        'runs',
+        'create',
         'test-app',
         'v1.0.0',
         '--items',
@@ -733,6 +812,42 @@ describe('CLI Integration Tests', () => {
 
       expect(consoleSpy.error).toHaveBeenCalledWith('❌ Invalid items JSON:', expect.any(Error));
       expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it('should reject combining --items and --items-file', async () => {
+      process.argv = [
+        'node',
+        'cli.js',
+        'runs',
+        'create',
+        'test-app',
+        'v1.0.0',
+        '--items',
+        '[]',
+        '--itemsFile',
+        './items.json',
+      ];
+
+      await main();
+
+      expect(consoleSpy.error).toHaveBeenCalledWith(expect.stringContaining('mutually exclusive'));
+    });
+
+    it('should create application run with items piped via stdin', async () => {
+      const stdinStream = Readable.from([
+        Buffer.from('[{"wsi_id": "wsi-456"}]'),
+      ]) as unknown as typeof process.stdin;
+      stdinStream.isTTY = false;
+      process.stdin = stdinStream;
+
+      process.argv = ['node', 'cli.js', 'runs', 'create', 'test-app', 'v1.0.0'];
+
+      await main();
+
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        '✅ Application run created successfully:',
+        expect.stringContaining('run_id')
+      );
     });
   });
 
@@ -748,10 +863,10 @@ describe('CLI Integration Tests', () => {
       expect(mockExit).toHaveBeenCalledWith(1);
     });
 
-    it('should handle API errors for get-run', async () => {
+    it('should handle API errors for runs get', async () => {
       server.use(http.get('*/v1/runs/:runId', () => HttpResponse.error()));
 
-      process.argv = ['node', 'cli.js', 'get-run', 'run-1'];
+      process.argv = ['node', 'cli.js', 'runs', 'get', 'run-1'];
 
       await main();
 
@@ -759,10 +874,10 @@ describe('CLI Integration Tests', () => {
       expect(mockExit).toHaveBeenCalledWith(1);
     });
 
-    it('should handle API errors for cancel-run', async () => {
+    it('should handle API errors for runs cancel', async () => {
       server.use(http.post('*/v1/runs/:runId/cancel', () => HttpResponse.error()));
 
-      process.argv = ['node', 'cli.js', 'cancel-run', 'run-1'];
+      process.argv = ['node', 'cli.js', 'runs', 'cancel', 'run-1'];
 
       await main();
 
@@ -773,10 +888,10 @@ describe('CLI Integration Tests', () => {
       expect(mockExit).toHaveBeenCalledWith(1);
     });
 
-    it('should handle API errors for list-run-results', async () => {
+    it('should handle API errors for runs results list', async () => {
       server.use(http.get('*/v1/runs/:runId/items', () => HttpResponse.error()));
 
-      process.argv = ['node', 'cli.js', 'list-run-results', 'run-1'];
+      process.argv = ['node', 'cli.js', 'runs', 'results', 'list', 'run-1'];
 
       await main();
 
@@ -787,10 +902,10 @@ describe('CLI Integration Tests', () => {
       expect(mockExit).toHaveBeenCalledWith(1);
     });
 
-    it('should handle API errors for list-application-runs', async () => {
+    it('should handle API errors for runs list', async () => {
       server.use(http.get('*/v1/runs', () => HttpResponse.error()));
 
-      process.argv = ['node', 'cli.js', 'list-application-runs'];
+      process.argv = ['node', 'cli.js', 'runs', 'list'];
 
       await main();
 
@@ -801,10 +916,10 @@ describe('CLI Integration Tests', () => {
       expect(mockExit).toHaveBeenCalledWith(1);
     });
 
-    it('should handle API errors for create-run', async () => {
+    it('should handle API errors for runs create', async () => {
       server.use(http.post('*/v1/runs', () => HttpResponse.error()));
 
-      process.argv = ['node', 'cli.js', 'create-run', 'test-app', 'v1.0.0'];
+      process.argv = ['node', 'cli.js', 'runs', 'create', 'test-app', 'v1.0.0'];
 
       await main();
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -8,12 +8,14 @@ import {
   handleInfo,
   testApi,
   listApplications,
+  getApplicationDetails,
   listApplicationVersions,
   listApplicationRuns,
   getRun,
   cancelApplicationRun,
   listRunResults,
   createApplicationRun,
+  resolveItemsInput,
   handleLogin,
   handleLogout,
   handleStatus,
@@ -56,184 +58,246 @@ export async function main() {
       }
     )
     .command(
-      'list-applications',
-      'List applications',
-      yargs => yargs,
-      argv => {
-        const env = environmentSchema.parse(argv.environment);
-        return listApplications(env, authService);
-      }
+      'applications',
+      'Manage applications',
+      appYargs =>
+        appYargs
+          .command(
+            'list',
+            'List applications',
+            yargs => yargs,
+            argv => {
+              const env = environmentSchema.parse(argv.environment);
+              return listApplications(env, authService);
+            }
+          )
+          .command(
+            'get <applicationId>',
+            'Get application details',
+            yargs =>
+              yargs.positional('applicationId', {
+                describe: 'Application ID to get details for',
+                type: 'string',
+                demandOption: true,
+              }),
+            argv => {
+              const env = environmentSchema.parse(argv.environment);
+              return getApplicationDetails(env, authService, argv.applicationId);
+            }
+          )
+          .command(
+            'versions',
+            'Manage application versions',
+            versionsYargs =>
+              versionsYargs
+                .command(
+                  'list <applicationId>',
+                  'List application versions',
+                  yargs =>
+                    yargs.positional('applicationId', {
+                      describe: 'Application ID',
+                      type: 'string',
+                      demandOption: true,
+                    }),
+                  argv => {
+                    const env = environmentSchema.parse(argv.environment);
+                    return listApplicationVersions(env, authService, argv.applicationId);
+                  }
+                )
+                .command(
+                  'get <applicationId> <versionNumber>',
+                  'Get application version details',
+                  yargs =>
+                    yargs
+                      .positional('applicationId', {
+                        describe: 'Application ID to get version details for',
+                        type: 'string',
+                        demandOption: true,
+                      })
+                      .positional('versionNumber', {
+                        describe: 'Version number of the application to get details for',
+                        type: 'string',
+                        demandOption: true,
+                      }),
+                  argv => {
+                    const env = environmentSchema.parse(argv.environment);
+                    return getApplicationVersionDetails(
+                      env,
+                      authService,
+                      argv.applicationId,
+                      argv.versionNumber
+                    );
+                  }
+                )
+                .demandCommand(1, 'You need at least one versions subcommand'),
+            () => undefined
+          )
+          .demandCommand(1, 'You need at least one applications subcommand'),
+      () => undefined
     )
     .command(
-      'list-application-versions <applicationId>',
-      'List application versions',
-      yargs =>
-        yargs.positional('applicationId', {
-          describe: 'Application ID',
-          type: 'string',
-          demandOption: true,
-        }),
-      argv => {
-        const env = environmentSchema.parse(argv.environment);
-        return listApplicationVersions(env, authService, argv.applicationId);
-      }
+      'runs',
+      'Manage application runs',
+      runsYargs =>
+        runsYargs
+          .command(
+            'create <applicationId> <versionNumber>',
+            'Create a new application run',
+            yargs =>
+              yargs
+                .positional('applicationId', {
+                  describe: 'Application ID to run',
+                  type: 'string',
+                  demandOption: true,
+                })
+                .positional('versionNumber', {
+                  describe: 'Version number of the application to run',
+                  type: 'string',
+                  demandOption: true,
+                })
+                .option('items', {
+                  describe: 'JSON string of items to process (array of objects)',
+                  type: 'string',
+                })
+                .option('itemsFile', {
+                  describe: 'Path to a JSON file containing the items to process',
+                  type: 'string',
+                })
+                .conflicts('items', 'itemsFile'),
+            async argv => {
+              const env = environmentSchema.parse(argv.environment);
+              const itemsJson = await resolveItemsInput({
+                items: argv.items,
+                itemsFile: argv.itemsFile,
+              });
+              return createApplicationRun(
+                env,
+                authService,
+                argv.applicationId,
+                argv.versionNumber,
+                itemsJson
+              );
+            }
+          )
+          .command(
+            'list',
+            'List application runs',
+            yargs =>
+              yargs
+                .option('applicationId', {
+                  describe: 'Filter by application ID',
+                  type: 'string',
+                })
+                .option('applicationVersion', {
+                  describe: 'Filter by application version',
+                  type: 'string',
+                })
+                .option('customMetadata', {
+                  describe: 'Filter by metadata key-value pairs (JSONPath string)',
+                  type: 'string',
+                })
+                .option('sort', {
+                  describe:
+                    'Sort by field (e.g., "run_id", "-status", "submitted_at"). Fields: run_id, application_version_id, organization_id, status, submitted_at, submitted_by.',
+                  type: 'string',
+                }),
+            argv => {
+              const env = environmentSchema.parse(argv.environment);
+              return listApplicationRuns(env, authService, {
+                applicationId: argv.applicationId,
+                applicationVersion: argv.applicationVersion,
+                customMetadata: argv.customMetadata,
+                sort: argv.sort,
+              });
+            }
+          )
+          .command(
+            'get <applicationRunId>',
+            'Get details of a specific application run',
+            yargs =>
+              yargs.positional('applicationRunId', {
+                describe: 'Application run ID to get details for',
+                type: 'string',
+                demandOption: true,
+              }),
+            argv => {
+              const env = environmentSchema.parse(argv.environment);
+              return getRun(env, authService, argv.applicationRunId);
+            }
+          )
+          .command(
+            'cancel <applicationRunId>',
+            'Cancel a specific application run',
+            yargs =>
+              yargs.positional('applicationRunId', {
+                describe: 'Application run ID to cancel',
+                type: 'string',
+                demandOption: true,
+              }),
+            argv => {
+              const env = environmentSchema.parse(argv.environment);
+              return cancelApplicationRun(env, authService, argv.applicationRunId);
+            }
+          )
+          .command(
+            'results',
+            'Manage application run results',
+            resultsYargs =>
+              resultsYargs
+                .command(
+                  'list <applicationRunId>',
+                  'List results for a specific application run',
+                  yargs =>
+                    yargs.positional('applicationRunId', {
+                      describe: 'Application run ID to get results for',
+                      type: 'string',
+                      demandOption: true,
+                    }),
+                  argv => {
+                    const env = environmentSchema.parse(argv.environment);
+                    return listRunResults(env, authService, argv.applicationRunId);
+                  }
+                )
+                .demandCommand(1, 'You need at least one results subcommand'),
+            () => undefined
+          )
+          .demandCommand(1, 'You need at least one runs subcommand'),
+      () => undefined
     )
     .command(
-      'get-application-version-details <applicationId> <versionNumber>',
-      'Get application version details',
-      yargs =>
-        yargs
-          .positional('applicationId', {
-            describe: 'Application ID to get version details for',
-            type: 'string',
-            demandOption: true,
+      'auth',
+      'Manage authentication',
+      authYargs =>
+        authYargs
+          .command(
+            'login',
+            'Login to the Aignostics Platform',
+            yargs =>
+              yargs.option('refreshToken', {
+                describe: 'Refresh token to use for login',
+                type: 'string',
+                demandOption: false,
+              }),
+            async argv => {
+              const env = environmentSchema.parse(argv.environment);
+              if (argv.refreshToken) {
+                await handleLoginWithRefreshToken(env, argv.refreshToken, authService);
+                return;
+              }
+              await handleLogin(env, authService);
+            }
+          )
+          .command('logout', 'Logout and remove stored token', {}, async argv => {
+            const env = environmentSchema.parse(argv.environment);
+            await handleLogout(env, authService);
           })
-          .positional('versionNumber', {
-            describe: 'Version number of the application to get details for',
-            type: 'string',
-            demandOption: true,
-          }),
-      argv => {
-        const env = environmentSchema.parse(argv.environment);
-        return getApplicationVersionDetails(
-          env,
-          authService,
-          argv.applicationId,
-          argv.versionNumber
-        );
-      }
-    )
-    .command(
-      'list-application-runs',
-      'List application runs',
-      yargs =>
-        yargs
-          .option('applicationId', {
-            describe: 'Filter by application ID',
-            type: 'string',
+          .command('status', 'Check authentication status', {}, async argv => {
+            const env = environmentSchema.parse(argv.environment);
+            await handleStatus(env, authService);
           })
-          .option('applicationVersion', {
-            describe: 'Filter by application version',
-            type: 'string',
-          })
-          .option('customMetadata', {
-            describe: 'Filter by metadata key-value pairs (JSONPath string)',
-            type: 'string',
-          })
-          .option('sort', {
-            describe:
-              'Sort by field (e.g., "run_id", "-status", "submitted_at"). Fields: run_id, application_version_id, organization_id, status, submitted_at, submitted_by.',
-            type: 'string',
-          }),
-      argv => {
-        const env = environmentSchema.parse(argv.environment);
-        return listApplicationRuns(env, authService, {
-          applicationId: argv.applicationId,
-          applicationVersion: argv.applicationVersion,
-          customMetadata: argv.customMetadata,
-          sort: argv.sort,
-        });
-      }
+          .demandCommand(1, 'You need at least one auth subcommand'),
+      () => undefined
     )
-    .command(
-      'get-run <applicationRunId>',
-      'Get details of a specific application run',
-      yargs =>
-        yargs.positional('applicationRunId', {
-          describe: 'Application run ID to get details for',
-          type: 'string',
-          demandOption: true,
-        }),
-      argv => {
-        const env = environmentSchema.parse(argv.environment);
-        return getRun(env, authService, argv.applicationRunId);
-      }
-    )
-    .command(
-      'cancel-run <applicationRunId>',
-      'Cancel a specific application run',
-      yargs =>
-        yargs.positional('applicationRunId', {
-          describe: 'Application run ID to cancel',
-          type: 'string',
-          demandOption: true,
-        }),
-      argv => {
-        const env = environmentSchema.parse(argv.environment);
-        return cancelApplicationRun(env, authService, argv.applicationRunId);
-      }
-    )
-    .command(
-      'list-run-results <applicationRunId>',
-      'List results for a specific application run',
-      yargs =>
-        yargs.positional('applicationRunId', {
-          describe: 'Application run ID to get results for',
-          type: 'string',
-          demandOption: true,
-        }),
-      argv => {
-        const env = environmentSchema.parse(argv.environment);
-        return listRunResults(env, authService, argv.applicationRunId);
-      }
-    )
-    .command(
-      'create-run <applicationId> <versionNumber>',
-      'Create a new application run',
-      yargs =>
-        yargs
-          .positional('applicationId', {
-            describe: 'Application ID to run',
-            type: 'string',
-            demandOption: true,
-          })
-          .positional('versionNumber', {
-            describe: 'Version number of the application to run',
-            type: 'string',
-            demandOption: true,
-          })
-          .option('items', {
-            describe: 'JSON string of items to process (array of objects)',
-            type: 'string',
-            default: '[]',
-          }),
-      argv => {
-        const env = environmentSchema.parse(argv.environment);
-        return createApplicationRun(
-          env,
-          authService,
-          argv.applicationId,
-          argv.versionNumber,
-          argv.items
-        );
-      }
-    )
-    .command(
-      'login',
-      'Login to the Aignostics Platform',
-      yargs =>
-        yargs.option('refreshToken', {
-          describe: 'Refresh token to use for login',
-          type: 'string',
-          demandOption: false,
-        }),
-      async argv => {
-        const env = environmentSchema.parse(argv.environment);
-        if (argv.refreshToken) {
-          await handleLoginWithRefreshToken(env, argv.refreshToken, authService);
-          return;
-        }
-        await handleLogin(env, authService);
-      }
-    )
-    .command('logout', 'Logout and remove stored token', {}, async argv => {
-      const env = environmentSchema.parse(argv.environment);
-      await handleLogout(env, authService);
-    })
-    .command('status', 'Check authentication status', {}, async argv => {
-      const env = environmentSchema.parse(argv.environment);
-      await handleStatus(env, authService);
-    })
     .help()
     .alias('help', 'h')
     .version()


### PR DESCRIPTION
## Summary

Replaces the CLI's flat command names with resource-based grouped subcommands, per [ADR 0001](docs/adr/0001-group-cli-commands-and-1to1-sdk-coverage.md):

- `applications`: `list`, `get <applicationId>`, `versions list <applicationId>`, `versions get <applicationId> <versionNumber>`
- `runs`: `create <applicationId> <versionNumber>`, `list`, `get <applicationRunId>`, `cancel <applicationRunId>`, `results list <applicationRunId>`
- `auth`: `login`, `logout`, `status`

`info` and `test-api` remain top-level, unchanged.

`runs create` now accepts items via `--items <json>`, `--items-file <path>`, or piped stdin, instead of only a raw `--items <json-string>` argument.

Scoped strictly to functionality already exposed by the SDK today — no new SDK methods were added.

## Breaking change

This is a breaking rewrite: old flat command names (`create-run`, `list-application-runs`, `cancel-run`, `login`, etc.) are removed outright, not kept as deprecated aliases. Ships as a major version bump.

## Changes

- `packages/cli/src/cli.ts`: regrouped all commands under `applications`, `runs`, `auth`.
- `packages/cli/src/cli-functions.ts`: added `getApplicationDetails` (backs `applications get`) and `resolveItemsInput` (backs `runs create`'s `--items`/`--items-file`/stdin support).
- Updated unit tests (`cli.test.ts`, `cli-functions.spec.ts`) and e2e tests/features to use the new command syntax.
- Updated `packages/cli/README.md` with the new usage.

## Testing

- `npm run test --workspace=@aignostics/cli` — 171 tests passing
- `npm run typecheck --workspace=@aignostics/cli` — clean
- `npm run lint` on changed files — clean

Refs: TSSDK-61
