### PR TITLE
chore(sdk): TSSDK-57 export ERROR_TERMINATION_REASON and RunStatus

### DIFF
--- a/packages/sdk/src/entities/run-item/utils.ts
+++ b/packages/sdk/src/entities/run-item/utils.ts
@@ -13,7 +13,7 @@ export const canDownloadItem = (item: ItemResultReadResponse): boolean => {
 };
 
 /** Termination reasons that mark a terminated item as FAILED. */
-const ERROR_TERMINATION_REASONS = new Set([
+export const ERROR_TERMINATION_REASONS = new Set([
   'CANCELED_BY_SYSTEM',
   'CANCELED_BY_USER',
   'SYSTEM_ERROR',

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -6,7 +6,7 @@ export * from './generated/index.js';
 // Export error classes
 export { BaseError, AuthenticationError, APIError, ConfigurationError } from './errors.js';
 
-export type { ApplicationRun } from './entities/application-run/types.js';
+export type { ApplicationRun, RunStatus } from './entities/application-run/types.js';
 export { processApplicationRun } from './entities/application-run/process-application-run.js';
 export {
   getRunProgress,
@@ -15,7 +15,11 @@ export {
 } from './entities/application-run/utils.js';
 export type { ApplicationRunItem, ItemStatus } from './entities/run-item/types.js';
 export { processRunItem } from './entities/run-item/process-run-item.js';
-export { canDownloadItem, getItemStatus } from './entities/run-item/utils.js';
+export {
+  canDownloadItem,
+  getItemStatus,
+  ERROR_TERMINATION_REASONS,
+} from './entities/run-item/utils.js';
 // Export main SDK and types
 export {
   PlatformSDKHttp,


### PR DESCRIPTION
export _ERROR_TERMINATION_REASON_ and _RunStatus_ type, so it will be possible to de-duplicate them from the platform-console:

* _[ERROR_TERMINATION_REASON](https://github.com/aignostics/platform-console/blob/41722f24c3f8f170f202e398866b0fa99c58936b/src/features/applications/run-item-service.ts#L60-L65)_;
* _[RunStatus](https://github.com/aignostics/platform-console/blob/41722f24c3f8f170f202e398866b0fa99c58936b/src/features/applications/run-status.ts#L13-L20)_.