### PR TITLE
feat(cli): add human-friendly text output format (--format text|json)

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -368,6 +368,42 @@ ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ---
 
+## @colors/colors
+
+**Version:** 1.5.0  
+**License:** MIT
+
+```
+MIT License
+
+Original Library
+  - Copyright (c) Marak Squires
+
+Additional Functionality
+ - Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+ - Copyright (c) DABH (https://github.com/DABH)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+```
+
+---
+
 ## @esbuild/aix-ppc64
 
 **Version:** 0.27.7  
@@ -8327,6 +8363,37 @@ No contributor can revoke this license.
 without any warranty or condition, and no contributor
 will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim.***
+```
+
+---
+
+## cli-table3
+
+**Version:** 0.6.5  
+**License:** MIT
+
+```
+MIT License
+
+Copyright (c) 2014 James Talmage <james.talmage@jrtechnical.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 ```
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -118,6 +118,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
@@ -3745,6 +3755,21 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/cli-table3": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
       }
     },
     "node_modules/cli-width": {
@@ -8522,6 +8547,7 @@
       "dependencies": {
         "@aignostics/sdk": "^3.6.1",
         "@napi-rs/keyring": "^1.1.8",
+        "cli-table3": "^0.6.5",
         "express": "^5.1.0",
         "open": "^11.0.0",
         "openid-client": "^5",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -12,6 +12,10 @@ npm install -g @aignostics/cli
 
 All commands accept a global `--environment` option (`production` [default], `staging`, `develop`).
 
+All commands also accept a global `--format` option (`text` [default], `json`). `text` prints a
+human-friendly table or summary showing the most relevant fields; `json` prints the full raw
+response, useful for scripting.
+
 ### Authentication
 
 ```bash

--- a/packages/cli/e2e/features/TC-application-execution.feature
+++ b/packages/cli/e2e/features/TC-application-execution.feature
@@ -14,7 +14,6 @@ Feature: Application Execution
     Given I have 2 valid input artifacts for "test-app" version "1.0.0"
     When I run the CLI command "runs create test-app 1.0.0 --items <items_json>"
     Then the exit code should be 0
-    And I should see "Application run created successfully:" in the output
     And the output should contain a JSON object with property "run_id"
 
   @id:TC-RUN-CREATE-INVALID-VERSION

--- a/packages/cli/e2e/specs/2-Application Discovery.e2e.test.ts
+++ b/packages/cli/e2e/specs/2-Application Discovery.e2e.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import { describe, it, expect } from 'vitest';
-import { executeCLI } from '../utils/command.js';
+import { describe, it, expect } from "vitest";
+import { executeCLI } from "../utils/command.js";
 
 type Application = {
   application_id: string;
@@ -18,137 +18,153 @@ type ApplicationVersion = {
   released_at: string;
 };
 
-describe('SWR Application List Retrieval', () => {
-  it('should retrieve all available applications for authenticated user', async ({ annotate }) => {
-    await annotate('SWR-APP-DISCOVERY-LIST', 'tests');
-    await annotate('TC-APP-LIST', 'id');
+describe("SWR Application List Retrieval", () => {
+  it("should retrieve all available applications for authenticated user", async ({
+    annotate,
+  }) => {
+    await annotate("SWR-APP-DISCOVERY-LIST", "tests");
+    await annotate("TC-APP-LIST", "id");
 
-    const { stdout, exitCode } = await executeCLI(['applications', 'list']);
+    const { stdout, exitCode } = await executeCLI([
+      "applications",
+      "list",
+      "--format",
+      "json",
+    ]);
 
     expect(exitCode).toBe(0);
 
-    // Parse the applications from the output
-    const output = String(stdout);
-    const applicationsMatch = output.match(/Applications: (\[.*\])/s);
-    expect(applicationsMatch).toBeTruthy();
-
-    const applications = JSON.parse(applicationsMatch![1]) as Array<Application>;
+    const applications = JSON.parse(String(stdout)) as Array<Application>;
     expect(Array.isArray(applications)).toBe(true);
   });
 });
 
-describe('SWR Application Details', () => {
-  it('should provide application identification, description, and regulatory compliance information', async ({
+describe("SWR Application Details", () => {
+  it("should provide application identification, description, and regulatory compliance information", async ({
     annotate,
   }) => {
-    await annotate('SWR-APP-DISCOVERY-VERSION-DETAILS', 'tests');
-    await annotate('TC-APP-DETAILS', 'id');
+    await annotate("SWR-APP-DISCOVERY-VERSION-DETAILS", "tests");
+    await annotate("TC-APP-DETAILS", "id");
 
-    const { stdout, exitCode } = await executeCLI(['applications', 'list']);
+    const { stdout, exitCode } = await executeCLI([
+      "applications",
+      "list",
+      "--format",
+      "json",
+    ]);
 
     expect(exitCode).toBe(0);
 
-    // Parse the applications from the output
-    const output = String(stdout);
-    const applicationsMatch = output.match(/Applications: (\[.*\])/s);
-    expect(applicationsMatch).toBeTruthy();
-
-    const applications = JSON.parse(applicationsMatch![1]) as Array<Application>;
+    const applications = JSON.parse(String(stdout)) as Array<Application>;
     expect(Array.isArray(applications)).toBe(true);
 
     // Find test-app in the list
-    const testApp = applications.find(app => app.application_id === 'test-app');
+    const testApp = applications.find(
+      (app) => app.application_id === "test-app",
+    );
     expect(testApp).toBeDefined();
 
     // Assert test-app properties
     expect(testApp).toMatchObject({
-      application_id: 'test-app',
-      name: 'Test Application',
+      application_id: "test-app",
+      name: "Test Application",
       regulatory_classes: expect.arrayContaining([expect.any(String)]),
       description: expect.any(String),
     });
   });
 });
 
-describe('SWR Version List Retrieval', () => {
-  it('should retrieve all versions for a specified application', async ({ annotate }) => {
-    await annotate('SWR-APP-DISCOVERY-VERSION-LIST', 'tests');
-    await annotate('SWR-APP-DISCOVERY-DETAILS', 'tests');
-    await annotate('TC-VERSION-LIST', 'id');
+describe("SWR Version List Retrieval", () => {
+  it("should retrieve all versions for a specified application", async ({
+    annotate,
+  }) => {
+    await annotate("SWR-APP-DISCOVERY-VERSION-LIST", "tests");
+    await annotate("SWR-APP-DISCOVERY-DETAILS", "tests");
+    await annotate("TC-VERSION-LIST", "id");
 
-    const { stdout, exitCode } = await executeCLI(['applications', 'versions', 'list', 'test-app']);
+    const { stdout, exitCode } = await executeCLI([
+      "applications",
+      "versions",
+      "list",
+      "test-app",
+      "--format",
+      "json",
+    ]);
 
     expect(exitCode).toBe(0);
 
-    // Parse the versions from the output
-    const output = String(stdout);
-    const versionsMatch = output.match(/Application versions for test-app: (\[.*\])/s);
-    expect(versionsMatch).toBeTruthy();
-
-    const versions = JSON.parse(versionsMatch![1]) as Array<ApplicationVersion>;
+    const versions = JSON.parse(String(stdout)) as Array<ApplicationVersion>;
     expect(Array.isArray(versions)).toBe(true);
     expect(versions.length).toBeGreaterThan(0);
 
     // Verify each version has required properties
-    versions.forEach(version => {
-      expect(version).toHaveProperty('number');
-      expect(version).toHaveProperty('released_at');
+    versions.forEach((version) => {
+      expect(version).toHaveProperty("number");
+      expect(version).toHaveProperty("released_at");
       expect(version.number).toMatch(/\d+\.\d+\.\d+/);
       expect(version.released_at).toMatch(
-        /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])T([01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:\.\d+)?Z$/
+        /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])T([01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:\.\d+)?Z$/,
       );
     });
   });
 
-  it('should return an error when the app does not exist', async ({ annotate }) => {
-    await annotate('TC-VERSION-LIST-NOT-FOUND', 'id');
+  it("should return an error when the app does not exist", async ({
+    annotate,
+  }) => {
+    await annotate("TC-VERSION-LIST-NOT-FOUND", "id");
 
-    const { stderr } = await executeCLI(['applications', 'versions', 'list', 'non-existent-app'], {
-      reject: false,
-    });
+    const { stderr } = await executeCLI(
+      ["applications", "versions", "list", "non-existent-app"],
+      {
+        reject: false,
+      },
+    );
 
     expect(stderr).toMatch(/API_ERROR'/);
     expect(stderr).toMatch(/application not found/);
   });
 });
 
-describe('SWR Specific Version Details', () => {
-  it('should provide details for a specific application version', async ({ annotate }) => {
-    await annotate('SWR-APP-DISCOVERY-VERSION-DETAILS', 'tests');
-    await annotate('TC-VERSION-DETAILS', 'id');
+describe("SWR Specific Version Details", () => {
+  it("should provide details for a specific application version", async ({
+    annotate,
+  }) => {
+    await annotate("SWR-APP-DISCOVERY-VERSION-DETAILS", "tests");
+    await annotate("TC-VERSION-DETAILS", "id");
 
     const { stdout, exitCode } = await executeCLI([
-      'applications',
-      'versions',
-      'get',
-      'test-app',
-      '1.0.0',
+      "applications",
+      "versions",
+      "get",
+      "test-app",
+      "1.0.0",
+      "--format",
+      "json",
     ]);
 
     expect(exitCode).toBe(0);
 
-    // Match the JSON object after the prefix
-    const detailsMatch = String(stdout).match(
-      /Application version details for test-app v1\.0\.0: (\{[\s\S]*\})/
-    );
-    expect(detailsMatch).toBeTruthy();
-
-    const versionDetails = JSON.parse(detailsMatch![1]);
+    const versionDetails = JSON.parse(String(stdout));
     expect(versionDetails).toMatchObject({
-      version_number: '1.0.0',
+      version_number: "1.0.0",
       changelog: expect.any(String),
       input_artifacts: expect.any(Array),
     });
   });
 
-  it('should return an error for non-existent application version', async ({ annotate }) => {
-    await annotate('SWR-ERROR-COMM-DIAGNOSTIC-CONTEXT', 'tests');
-    await annotate('SWR-ERROR-COMM-CLASSIFICATION', 'tests');
-    await annotate('TC-VERSION-DETAILS-NOT-FOUND', 'id');
+  it("should return an error for non-existent application version", async ({
+    annotate,
+  }) => {
+    await annotate("SWR-ERROR-COMM-DIAGNOSTIC-CONTEXT", "tests");
+    await annotate("SWR-ERROR-COMM-CLASSIFICATION", "tests");
+    await annotate("TC-VERSION-DETAILS-NOT-FOUND", "id");
 
-    const { stderr } = await executeCLI(['applications', 'versions', 'get', 'test-app', '2.0.0'], {
-      reject: false,
-    });
+    const { stderr } = await executeCLI(
+      ["applications", "versions", "get", "test-app", "2.0.0"],
+      {
+        reject: false,
+      },
+    );
     expect(stderr).toMatch(/API_ERROR/);
     expect(stderr).toMatch(/Application version not found/);
   });

--- a/packages/cli/e2e/specs/3-Application-execution.e2e.test.ts
+++ b/packages/cli/e2e/specs/3-Application-execution.e2e.test.ts
@@ -1,50 +1,58 @@
-import { describe, it, expect } from 'vitest';
-import { executeCLI } from '../utils/command.js';
-import { generateInputArtifactsForTest } from '../utils/getAppInputArtifacts.js';
-import { getAppLatestVersion } from '../utils/getAppLatestVersion.js';
+import { describe, it, expect } from "vitest";
+import { executeCLI } from "../utils/command.js";
+import { generateInputArtifactsForTest } from "../utils/getAppInputArtifacts.js";
+import { getAppLatestVersion } from "../utils/getAppLatestVersion.js";
 
-describe('SWR Application Execution access', async () => {
-  const latestVersion = await getAppLatestVersion('test-app');
+describe("SWR Application Execution access", async () => {
+  const latestVersion = await getAppLatestVersion("test-app");
 
-  it('Should create application runs with specified application version, input items, and item- and run metadata and return a unique run identifier upon successful creation.', async ({
+  it("Should create application runs with specified application version, input items, and item- and run metadata and return a unique run identifier upon successful creation.", async ({
     annotate,
   }) => {
-    await annotate('SWR-APP-EXEC-RUN-CREATION', 'tests');
-    await annotate('SWR-APP-EXEC-INPUT-ARTIFACT', 'tests');
-    await annotate('TC-RUN-CREATE', 'id');
+    await annotate("SWR-APP-EXEC-RUN-CREATION", "tests");
+    await annotate("SWR-APP-EXEC-INPUT-ARTIFACT", "tests");
+    await annotate("TC-RUN-CREATE", "id");
 
-    const items = await generateInputArtifactsForTest('test-app', latestVersion, 2);
+    const items = await generateInputArtifactsForTest(
+      "test-app",
+      latestVersion,
+      2,
+    );
 
     const { stdout, exitCode } = await executeCLI([
-      'runs',
-      'create',
-      'test-app',
-      '1.0.0',
-      '--items',
+      "runs",
+      "create",
+      "test-app",
+      "1.0.0",
+      "--items",
       JSON.stringify(items),
+      "--format",
+      "json",
     ]);
 
     expect(exitCode).toBe(0);
 
-    // Match the JSON object after the prefix
-    const runDetails = String(stdout).match(/Application run created successfully: (\{[\s\S]*\})/);
-    expect(runDetails).toBeTruthy();
+    const runDetails = JSON.parse(String(stdout)) as { run_id: string };
 
-    const runId = JSON.parse(runDetails![1]) as string;
-
-    expect(runId).toHaveProperty('run_id');
+    expect(runDetails).toHaveProperty("run_id");
   });
 
-  it('Should return an error on on non-existent version', async ({ annotate }) => {
-    await annotate('SWR-ERROR-COMM-DIAGNOSTIC-CONTEXT', 'tests');
-    await annotate('SWR-ERROR-COMM-CLI-OUTPUT', 'tests');
-    await annotate('TC-RUN-CREATE-INVALID-VERSION', 'id');
+  it("Should return an error on on non-existent version", async ({
+    annotate,
+  }) => {
+    await annotate("SWR-ERROR-COMM-DIAGNOSTIC-CONTEXT", "tests");
+    await annotate("SWR-ERROR-COMM-CLI-OUTPUT", "tests");
+    await annotate("TC-RUN-CREATE-INVALID-VERSION", "id");
 
-    const items = await generateInputArtifactsForTest('test-app', latestVersion, 2);
+    const items = await generateInputArtifactsForTest(
+      "test-app",
+      latestVersion,
+      2,
+    );
 
     const { stderr, exitCode } = await executeCLI(
-      ['runs', 'create', 'test-app', '2.0.0', '--items', JSON.stringify(items)],
-      { reject: false }
+      ["runs", "create", "test-app", "2.0.0", "--items", JSON.stringify(items)],
+      { reject: false },
     );
 
     // Verify error written to stderr
@@ -55,23 +63,25 @@ describe('SWR Application Execution access', async () => {
     expect(exitCode).not.toBe(0);
   });
 
-  it('Should return an error on missing arguments', async ({ annotate }) => {
-    await annotate('SWR-ERROR-COMM-MESSAGES', 'tests');
-    await annotate('TC-RUN-CREATE-MISSING-ARGS', 'id');
+  it("Should return an error on missing arguments", async ({ annotate }) => {
+    await annotate("SWR-ERROR-COMM-MESSAGES", "tests");
+    await annotate("TC-RUN-CREATE-MISSING-ARGS", "id");
 
-    const { stderr } = await executeCLI(['runs', 'create'], { reject: false });
-    expect(stderr).toContain('❌ Not enough non-option arguments: got 0, need at least 2');
+    const { stderr } = await executeCLI(["runs", "create"], { reject: false });
+    expect(stderr).toContain(
+      "❌ Not enough non-option arguments: got 0, need at least 2",
+    );
   });
 
-  it('Should validate items before submission', async ({ annotate }) => {
-    await annotate('SWR-APP-EXEC-REQUEST-VALIDATION', 'tests');
-    await annotate('SWR-ERROR-COMM-MESSAGES', 'tests');
-    await annotate('TC-RUN-CREATE-INVALID-JSON', 'id');
+  it("Should validate items before submission", async ({ annotate }) => {
+    await annotate("SWR-APP-EXEC-REQUEST-VALIDATION", "tests");
+    await annotate("SWR-ERROR-COMM-MESSAGES", "tests");
+    await annotate("TC-RUN-CREATE-INVALID-JSON", "id");
 
     const { stderr } = await executeCLI(
-      ['runs', 'create', 'test-app', latestVersion, '--items', 'invalid-json'],
-      { reject: false }
+      ["runs", "create", "test-app", latestVersion, "--items", "invalid-json"],
+      { reject: false },
     );
-    expect(stderr).toContain('❌ Invalid items JSON:');
+    expect(stderr).toContain("❌ Invalid items JSON:");
   });
 });

--- a/packages/cli/e2e/specs/4-Applicatioin-run-management.e2e.test.ts
+++ b/packages/cli/e2e/specs/4-Applicatioin-run-management.e2e.test.ts
@@ -16,15 +16,13 @@ describe('SWR Application Run management', () => {
       'test-app',
       '--applicationVersion',
       '1.0.0',
+      '--format',
+      'json',
     ]);
 
     expect(exitCode).toBe(0);
 
-    // Match the JSON array after the prefix
-    const runList = String(stdout).match(/Application runs: (\[.*\])/s);
-    expect(runList).toBeTruthy();
-
-    const runs = JSON.parse(runList![1]) as Array<RunReadResponse>;
+    const runs = JSON.parse(String(stdout)) as Array<RunReadResponse>;
     expect(Array.isArray(runs)).toBe(true);
 
     expect(runs[0].application_id).toBe('test-app');
@@ -42,28 +40,25 @@ describe('SWR Application Run management', () => {
       'test-app',
       '--applicationVersion',
       '1.0.0',
+      '--format',
+      'json',
     ]);
 
     expect(exitCode).toBe(0);
-    const runList = String(stdout).match(/Application runs: (\[.*\])/s);
-
-    const runs = JSON.parse(runList![1]) as Array<RunReadResponse>;
+    const runs = JSON.parse(String(stdout)) as Array<RunReadResponse>;
     const latestRunId = runs[0].run_id;
 
     const { stdout: runDetailsStdout, exitCode: runDetailsExitCode } = await executeCLI([
       'runs',
       'get',
       latestRunId,
+      '--format',
+      'json',
     ]);
 
     expect(runDetailsExitCode).toBe(0);
 
-    const runDetailsMatch = String(runDetailsStdout).match(
-      new RegExp(`Run details for ${latestRunId}: (\\{.*\\})`, 's')
-    );
-    expect(runDetailsMatch).toBeTruthy();
-
-    const runDetails = JSON.parse(runDetailsMatch![1]) as RunReadResponse;
+    const runDetails = JSON.parse(String(runDetailsStdout)) as RunReadResponse;
     expect(runDetails.run_id).toBe(latestRunId);
     expect(runDetails.application_id).toBe('test-app');
   });
@@ -79,12 +74,12 @@ describe('SWR Application Run management', () => {
       'test-app',
       '--applicationVersion',
       '1.0.0',
+      '--format',
+      'json',
     ]);
 
     expect(exitCode).toBe(0);
-    const runList = String(stdout).match(/Application runs: (\[.*\])/s);
-
-    const runs = JSON.parse(runList![1]) as Array<RunReadResponse>;
+    const runs = JSON.parse(String(stdout)) as Array<RunReadResponse>;
     const pendingRunId = runs.find(run => run.state === 'PENDING')?.run_id;
 
     if (!pendingRunId) {

--- a/packages/cli/e2e/specs/5-Application-results-access.e2e.test.ts
+++ b/packages/cli/e2e/specs/5-Application-results-access.e2e.test.ts
@@ -16,12 +16,12 @@ describe('Application Results Access', () => {
       'test-app',
       '--applicationVersion',
       '1.0.0',
+      '--format',
+      'json',
     ]);
 
     expect(exitCode).toBe(0);
-    const runList = String(stdout).match(/Application runs: (\[.*\])/s);
-
-    const runs = JSON.parse(runList![1]) as Array<RunReadResponse>;
+    const runs = JSON.parse(String(stdout)) as Array<RunReadResponse>;
     const latestRunId = runs[0].run_id;
 
     const { stdout: runResultsStdout, exitCode: runResultsExitCode } = await executeCLI([
@@ -29,16 +29,13 @@ describe('Application Results Access', () => {
       'results',
       'list',
       latestRunId,
+      '--format',
+      'json',
     ]);
 
     expect(runResultsExitCode).toBe(0);
 
-    const runResultsMatch = String(runResultsStdout).match(
-      new RegExp(`Run results for ${latestRunId}: (\\[.*\\])`, 's')
-    );
-    expect(runResultsMatch).toBeTruthy();
-
-    const runResults = JSON.parse(runResultsMatch![1]) as RunReadResponse[];
+    const runResults = JSON.parse(String(runResultsStdout)) as RunReadResponse[];
     expect(Array.isArray(runResults)).toBe(true);
   });
 
@@ -56,12 +53,12 @@ describe('Application Results Access', () => {
       'test-app',
       '--applicationVersion',
       '1.0.0',
+      '--format',
+      'json',
     ]);
 
     expect(exitCode).toBe(0);
-    const runList = String(stdout).match(/Application runs: (\[.*\])/s);
-
-    const runs = JSON.parse(runList![1]) as Array<RunReadResponse>;
+    const runs = JSON.parse(String(stdout)) as Array<RunReadResponse>;
     const latestRunId = runs[0].run_id;
 
     const { stdout: runResultsStdout, exitCode: runResultsExitCode } = await executeCLI([
@@ -69,16 +66,13 @@ describe('Application Results Access', () => {
       'results',
       'list',
       latestRunId,
+      '--format',
+      'json',
     ]);
 
     expect(runResultsExitCode).toBe(0);
 
-    const runResultsMatch = String(runResultsStdout).match(
-      new RegExp(`Run results for ${latestRunId}: (\\[.*\\])`, 's')
-    );
-    expect(runResultsMatch).toBeTruthy();
-
-    const runResults = JSON.parse(runResultsMatch![1]) as ItemResultReadResponse[];
+    const runResults = JSON.parse(String(runResultsStdout)) as ItemResultReadResponse[];
 
     runResults.forEach(result => {
       expect(result).toHaveProperty('state');

--- a/packages/cli/e2e/utils/getAppInputArtifacts.ts
+++ b/packages/cli/e2e/utils/getAppInputArtifacts.ts
@@ -1,5 +1,5 @@
-import { VersionReadResponse } from '@aignostics/sdk';
-import { executeCLI } from './command.js';
+import { VersionReadResponse } from "@aignostics/sdk";
+import { executeCLI } from "./command.js";
 
 interface JsonSchema {
   $ref?: string;
@@ -25,7 +25,10 @@ interface SchemaDefinitions {
 /**
  * Generate a value based on JSON Schema property definition
  */
-const generateValueFromProperty = (propName: string, propSchema: JsonSchema): unknown => {
+const generateValueFromProperty = (
+  propName: string,
+  propSchema: JsonSchema,
+): unknown => {
   // Handle $ref references
   if (propSchema.$ref) {
     return { $ref: propSchema.$ref }; // Will be resolved later
@@ -33,12 +36,16 @@ const generateValueFromProperty = (propName: string, propSchema: JsonSchema): un
 
   // Handle anyOf - pick the first non-null option
   if (propSchema.anyOf) {
-    const nonNullOption = propSchema.anyOf.find(option => option.type !== 'null' && option.$ref);
+    const nonNullOption = propSchema.anyOf.find(
+      (option) => option.type !== "null" && option.$ref,
+    );
     if (nonNullOption) {
       return generateValueFromProperty(propName, nonNullOption);
     }
     // If no $ref, pick first non-null option
-    const firstValidOption = propSchema.anyOf.find(option => option.type !== 'null');
+    const firstValidOption = propSchema.anyOf.find(
+      (option) => option.type !== "null",
+    );
     if (firstValidOption) {
       return generateValueFromProperty(propName, firstValidOption);
     }
@@ -47,10 +54,10 @@ const generateValueFromProperty = (propName: string, propSchema: JsonSchema): un
   // Handle allOf (merge schemas)
   if (propSchema.allOf) {
     const merged: Record<string, unknown> = {};
-    propSchema.allOf.forEach(schema => {
+    propSchema.allOf.forEach((schema) => {
       if (schema.$ref) {
         merged.$ref = schema.$ref;
-      } else if (schema.type === 'object' && schema.properties) {
+      } else if (schema.type === "object" && schema.properties) {
         Object.entries(schema.properties).forEach(([key, val]) => {
           merged[key] = generateValueFromProperty(key, val);
         });
@@ -62,7 +69,7 @@ const generateValueFromProperty = (propName: string, propSchema: JsonSchema): un
   const type = propSchema.type;
 
   switch (type) {
-    case 'string':
+    case "string":
       // Use const if available (fixed value)
       if (propSchema.const !== undefined) {
         return propSchema.const;
@@ -72,41 +79,45 @@ const generateValueFromProperty = (propName: string, propSchema: JsonSchema): un
         return propSchema.enum[0];
       }
       // Use format hints
-      if (propSchema.format === 'uri' || propName.includes('url')) {
-        return 'https://example.com/sample-file.tiff';
+      if (propSchema.format === "uri" || propName.includes("url")) {
+        return "https://example.com/sample-file.tiff";
       }
-      if (propName.includes('checksum') || propName === 'checksum_base64_crc32c') {
-        return '64RKKA==';
+      if (
+        propName.includes("checksum") ||
+        propName === "checksum_base64_crc32c"
+      ) {
+        return "64RKKA==";
       }
       // Use examples or defaults
       if (propSchema.example !== undefined) return propSchema.example;
       if (propSchema.default !== undefined) return propSchema.default;
-      return 'sample_value';
+      return "sample_value";
 
-    case 'integer':
-    case 'number':
+    case "integer":
+    case "number":
       // Use examples or defaults
       if (propSchema.example !== undefined) return propSchema.example;
       if (propSchema.default !== undefined) return propSchema.default;
       // Use minimum if provided
       if (propSchema.minimum !== undefined) return propSchema.minimum;
       // Generate sensible defaults based on property name
-      if (propName.includes('width') || propName === 'width_px') return 136223;
-      if (propName.includes('height') || propName === 'height_px') return 87761;
-      if (propName.includes('resolution') || propName === 'resolution_mpp') return 0.2628238;
-      return type === 'integer' ? 100000 : 0.5;
+      if (propName.includes("width") || propName === "width_px") return 136223;
+      if (propName.includes("height") || propName === "height_px") return 87761;
+      if (propName.includes("resolution") || propName === "resolution_mpp")
+        return 0.2628238;
+      return type === "integer" ? 100000 : 0.5;
 
-    case 'boolean':
+    case "boolean":
       if (propSchema.default !== undefined) return propSchema.default;
       return true;
 
-    case 'array':
+    case "array":
       if (propSchema.items) {
         return [generateValueFromProperty(propName, propSchema.items)];
       }
       return [];
 
-    case 'object': {
+    case "object": {
       const obj: Record<string, unknown> = {};
       if (propSchema.properties) {
         Object.entries(propSchema.properties).forEach(([key, schema]) => {
@@ -127,12 +138,14 @@ const generateValueFromProperty = (propName: string, propSchema: JsonSchema): un
 const resolveRefs = (data: unknown, defs: SchemaDefinitions): unknown => {
   if (data === null || data === undefined) return data;
 
-  if (typeof data !== 'object') return data;
+  if (typeof data !== "object") return data;
 
   // Handle $ref
-  if (typeof data === 'object' && data !== null && '$ref' in data) {
+  if (typeof data === "object" && data !== null && "$ref" in data) {
     const refValue = (data as { $ref: string }).$ref;
-    const refPath = refValue.replace('#/$defs/', '').replace('#/definitions/', '');
+    const refPath = refValue
+      .replace("#/$defs/", "")
+      .replace("#/definitions/", "");
     if (defs[refPath]) {
       return generateMetadataFromSchema(defs[refPath], defs);
     }
@@ -142,7 +155,7 @@ const resolveRefs = (data: unknown, defs: SchemaDefinitions): unknown => {
 
   // Handle arrays
   if (Array.isArray(data)) {
-    return data.map(item => resolveRefs(item, defs));
+    return data.map((item) => resolveRefs(item, defs));
   }
 
   // Handle objects
@@ -158,13 +171,15 @@ const resolveRefs = (data: unknown, defs: SchemaDefinitions): unknown => {
  */
 const generateMetadataFromSchema = (
   schema: JsonSchema,
-  defs?: SchemaDefinitions
+  defs?: SchemaDefinitions,
 ): Record<string, unknown> => {
-  if (!schema || typeof schema !== 'object') return {};
+  if (!schema || typeof schema !== "object") return {};
 
   // Handle $ref at root level
   if (schema.$ref) {
-    const refPath = schema.$ref.replace('#/$defs/', '').replace('#/definitions/', '');
+    const refPath = schema.$ref
+      .replace("#/$defs/", "")
+      .replace("#/definitions/", "");
     if (defs && defs[refPath]) {
       return generateMetadataFromSchema(defs[refPath], defs);
     }
@@ -184,25 +199,32 @@ const generateMetadataFromSchema = (
   }
 
   // Resolve any $ref in the generated metadata
-  return defs ? (resolveRefs(metadata, defs) as Record<string, unknown>) : metadata;
+  return defs
+    ? (resolveRefs(metadata, defs) as Record<string, unknown>)
+    : metadata;
 };
 
-export const getAppInputArtifacts = async (applicationId: string, version: string) => {
-  const { stdout } = await executeCLI(['applications', 'versions', 'get', applicationId, version]);
+export const getAppInputArtifacts = async (
+  applicationId: string,
+  version: string,
+) => {
+  const { stdout } = await executeCLI([
+    "applications",
+    "versions",
+    "get",
+    applicationId,
+    version,
+    "--format",
+    "json",
+  ]);
 
-  // Match the JSON object after the prefix
-  const detailsMatch = String(stdout).match(
-    new RegExp(`Application version details for ${applicationId} v${version}: (\\{[\\s\\S]*\\})`)
-  );
+  const versionDetails = JSON.parse(String(stdout)) as VersionReadResponse;
 
-  if (!detailsMatch) {
-    throw new Error('Failed to retrieve application version details.');
-  }
-
-  const versionDetails = JSON.parse(detailsMatch[1] || '') as VersionReadResponse;
-
-  if (!versionDetails.input_artifacts || versionDetails.input_artifacts.length === 0) {
-    throw new Error('No input artifacts found in application version details.');
+  if (
+    !versionDetails.input_artifacts ||
+    versionDetails.input_artifacts.length === 0
+  ) {
+    throw new Error("No input artifacts found in application version details.");
   }
 
   return versionDetails.input_artifacts;
@@ -214,23 +236,28 @@ export const getAppInputArtifacts = async (applicationId: string, version: strin
 export const generateInputArtifactsForTest = async (
   applicationId: string,
   version: string,
-  itemCount = 2
+  itemCount = 2,
 ) => {
   const inputArtifacts = await getAppInputArtifacts(applicationId, version);
   const firstArtifact = inputArtifacts[0];
 
   if (!firstArtifact) {
-    throw new Error('No input artifacts found for this application version.');
+    throw new Error("No input artifacts found for this application version.");
   }
 
-  const metadataSchema = firstArtifact.metadata_schema as JsonSchema | undefined;
+  const metadataSchema = firstArtifact.metadata_schema as
+    | JsonSchema
+    | undefined;
 
   if (!metadataSchema) {
-    throw new Error('No metadata schema found in input artifacts.');
+    throw new Error("No metadata schema found in input artifacts.");
   }
 
   // Generate metadata from schema
-  const sampleMetadata = generateMetadataFromSchema(metadataSchema, metadataSchema.$defs);
+  const sampleMetadata = generateMetadataFromSchema(
+    metadataSchema,
+    metadataSchema.$defs,
+  );
 
   // Generate test items
   const items = [];
@@ -239,7 +266,7 @@ export const generateInputArtifactsForTest = async (
       external_id: `slide_${i}`,
       input_artifacts: [
         {
-          name: firstArtifact.name || 'whole_slide_image',
+          name: firstArtifact.name || "whole_slide_image",
           download_url: `https://example.com/slides/slide_${i}.tiff`,
           metadata: sampleMetadata,
         },

--- a/packages/cli/e2e/utils/getAppLatestVersion.ts
+++ b/packages/cli/e2e/utils/getAppLatestVersion.ts
@@ -2,18 +2,16 @@ import { ApplicationVersion } from '@aignostics/sdk';
 import { executeCLI } from './command.js';
 
 export const getAppLatestVersion = async (applicationId: string) => {
-  const { stdout } = await executeCLI(['applications', 'versions', 'list', applicationId]);
+  const { stdout } = await executeCLI([
+    'applications',
+    'versions',
+    'list',
+    applicationId,
+    '--format',
+    'json',
+  ]);
 
-  // Parse the versions from the output
-  const output = String(stdout);
-  const versionsMatch = output.match(
-    new RegExp(`Application versions for ${applicationId}: (\\[.*\\])`, 's')
-  );
-
-  if (!versionsMatch) {
-    throw new Error('Failed to retrieve application versions.');
-  }
-  const versions = JSON.parse(versionsMatch[1] || '[]') as Array<ApplicationVersion>;
+  const versions = JSON.parse(String(stdout)) as Array<ApplicationVersion>;
 
   return versions[0]?.number;
 };

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@aignostics/sdk": "^3.6.1",
     "@napi-rs/keyring": "^1.1.8",
+    "cli-table3": "^0.6.5",
     "express": "^5.1.0",
     "open": "^11.0.0",
     "openid-client": "^5",

--- a/packages/cli/src/cli-functions.spec.ts
+++ b/packages/cli/src/cli-functions.spec.ts
@@ -1,5 +1,13 @@
 /* eslint-disable @typescript-eslint/unbound-method */
-import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from "vitest";
 import {
   handleInfo,
   testApi,
@@ -29,29 +37,32 @@ import {
   listShareTokens,
   getShareToken,
   revokeShareToken,
-} from './cli-functions.js';
-import { PlatformSDK, PlatformSDKHttp } from '@aignostics/sdk';
-import { AuthService, AuthState } from './utils/auth.js';
-import { startCallbackServer, waitForCallback } from './utils/oauth-callback-server.js';
-import crypto from 'crypto';
-import * as fs from 'fs';
-import { join } from 'path';
-import { tmpdir } from 'os';
-import { Readable } from 'stream';
-import { EnvironmentKey } from './utils/environment.js';
+} from "./cli-functions.js";
+import { PlatformSDK, PlatformSDKHttp } from "@aignostics/sdk";
+import { AuthService, AuthState } from "./utils/auth.js";
+import {
+  startCallbackServer,
+  waitForCallback,
+} from "./utils/oauth-callback-server.js";
+import crypto from "crypto";
+import * as fs from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { Readable } from "stream";
+import { EnvironmentKey } from "./utils/environment.js";
 
 // Mock external dependencies
-vi.mock('./utils/oauth-callback-server');
-vi.mock('crypto');
+vi.mock("./utils/oauth-callback-server");
+vi.mock("crypto");
 
 // Mock process.exit to prevent test runner from exiting
 const mockExit = vi.fn();
-vi.stubGlobal('process', {
+vi.stubGlobal("process", {
   ...process,
   exit: mockExit,
 });
 
-vi.mock('@aignostics/sdk', () => ({
+vi.mock("@aignostics/sdk", () => ({
   PlatformSDKHttp: vi.fn(),
   PlatformSDK: vi.fn(),
 }));
@@ -86,7 +97,7 @@ const platformSDKMock = {
 
 // Mock AuthService
 const mockAuthService = {
-  getValidAccessToken: vi.fn().mockResolvedValue('mock-token'),
+  getValidAccessToken: vi.fn().mockResolvedValue("mock-token"),
   loginWithCallback: vi.fn(),
   completeLogin: vi.fn(),
   logout: vi.fn(),
@@ -95,12 +106,12 @@ const mockAuthService = {
 } as unknown as AuthService;
 
 // Mock package.json
-vi.mock('../../package.json', () => ({
-  default: { version: '0.0.0-development' },
-  version: '0.0.0-development',
+vi.mock("../../package.json", () => ({
+  default: { version: "0.0.0-development" },
+  version: "0.0.0-development",
 }));
 
-describe('CLI Functions Unit Tests', () => {
+describe("CLI Functions Unit Tests", () => {
   let consoleSpy: {
     log: ReturnType<typeof vi.spyOn>;
     error: ReturnType<typeof vi.spyOn>;
@@ -112,10 +123,10 @@ describe('CLI Functions Unit Tests', () => {
 
     // Mock console methods to avoid noise in tests
     consoleSpy = {
-      log: vi.spyOn(console, 'log').mockImplementation(() => {}),
-      error: vi.spyOn(console, 'error').mockImplementation(() => {}),
+      log: vi.spyOn(console, "log").mockImplementation(() => {}),
+      error: vi.spyOn(console, "error").mockImplementation(() => {}),
     };
-    vi.mocked(PlatformSDKHttp).mockImplementation(config => {
+    vi.mocked(PlatformSDKHttp).mockImplementation((config) => {
       // Capture and call the tokenProvider to ensure coverage
       if (config?.tokenProvider) {
         // TODO: get rid of this by adding integration tests that actually cover this
@@ -125,964 +136,1036 @@ describe('CLI Functions Unit Tests', () => {
     });
   });
 
-  describe('handleInfo', () => {
-    it('should display SDK information', () => {
+  describe("handleInfo", () => {
+    it("should display SDK information", () => {
       handleInfo();
 
-      expect(consoleSpy.log).toHaveBeenCalledWith('Aignostics Platform SDK');
-      expect(consoleSpy.log).toHaveBeenCalledWith('Version:', '0.0.0-development');
+      expect(consoleSpy.log).toHaveBeenCalledWith("Aignostics Platform SDK");
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        "Version:",
+        "0.0.0-development",
+      );
     });
   });
 
-  describe('testApi', () => {
-    it('should test API connection successfully', async () => {
+  describe("testApi", () => {
+    it("should test API connection successfully", async () => {
       // Set up mock server for successful response
       platformSDKMock.testConnection.mockResolvedValue(true);
 
-      await testApi('production', mockAuthService);
+      await testApi("production", mockAuthService);
 
-      expect(consoleSpy.log).toHaveBeenCalledWith('✅ API connection successful');
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        "✅ API connection successful",
+      );
     });
 
-    it('should handle API connection failure', async () => {
+    it("should handle API connection failure", async () => {
       // Set up mock server for error response
       platformSDKMock.testConnection.mockResolvedValue(false);
 
-      await testApi('production', mockAuthService);
+      await testApi("production", mockAuthService);
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ API connection failed, bad response status code'
+        "❌ API connection failed, bad response status code",
       );
       expect(mockExit).not.toHaveBeenCalled();
     });
 
-    it('should handle API connection failure', async () => {
+    it("should handle API connection failure", async () => {
       // Set up mock server for error response
-      platformSDKMock.testConnection.mockRejectedValue(new Error('Connection failed'));
+      platformSDKMock.testConnection.mockRejectedValue(
+        new Error("Connection failed"),
+      );
 
-      await testApi('production', mockAuthService);
+      await testApi("production", mockAuthService);
 
-      expect(consoleSpy.error).toHaveBeenCalledWith('❌ API connection failed:', expect.any(Error));
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        "❌ API connection failed:",
+        expect.any(Error),
+      );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
 
-    it('should handle network errors', async () => {
+    it("should handle network errors", async () => {
       // Set up mock server for network error
-      platformSDKMock.testConnection.mockRejectedValue(new Error('Network error'));
+      platformSDKMock.testConnection.mockRejectedValue(
+        new Error("Network error"),
+      );
 
-      await testApi('production', mockAuthService);
+      await testApi("production", mockAuthService);
 
-      expect(consoleSpy.error).toHaveBeenCalledWith('❌ API connection failed:', expect.any(Error));
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        "❌ API connection failed:",
+        expect.any(Error),
+      );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
   });
 
-  describe('listApplications', () => {
-    it('should list applications successfully', async () => {
+  describe("listApplications", () => {
+    it("should return the list of applications", async () => {
       const listApplicationsResponse = {
         applications: [
-          { id: 'app1', name: 'Application 1' },
-          { id: 'app2', name: 'Application 2' },
+          { id: "app1", name: "Application 1" },
+          { id: "app2", name: "Application 2" },
         ],
       };
       // Set up mock server for successful response
-      platformSDKMock.listApplications.mockResolvedValue(listApplicationsResponse);
-
-      await listApplications('production', mockAuthService);
-
-      expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Applications:',
-        JSON.stringify(listApplicationsResponse, null, 2)
+      platformSDKMock.listApplications.mockResolvedValue(
+        listApplicationsResponse,
       );
+
+      const result = await listApplications("production", mockAuthService);
+
+      expect(result).toEqual(listApplicationsResponse);
     });
 
-    it('should handle empty applications list', async () => {
+    it("should handle empty applications list", async () => {
       const listApplicationsResponse = { applications: [] };
       // Set up mock server for empty response
-      platformSDKMock.listApplications.mockResolvedValue(listApplicationsResponse);
-
-      await listApplications('production', mockAuthService);
-
-      expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Applications:',
-        JSON.stringify(listApplicationsResponse, null, 2)
+      platformSDKMock.listApplications.mockResolvedValue(
+        listApplicationsResponse,
       );
+
+      const result = await listApplications("production", mockAuthService);
+
+      expect(result).toEqual(listApplicationsResponse);
     });
 
-    it('should throw error when API fails', async () => {
+    it("should throw error when API fails", async () => {
       // Set up mock server for error response
-      platformSDKMock.listApplications.mockRejectedValue(new Error('API error'));
+      platformSDKMock.listApplications.mockRejectedValue(
+        new Error("API error"),
+      );
 
-      await expect(listApplications('production', mockAuthService)).rejects.toThrow();
+      await expect(
+        listApplications("production", mockAuthService),
+      ).rejects.toThrow();
     });
   });
 
-  describe('getApplicationVersionDetails', () => {
-    it('should get application version details successfully', async () => {
+  describe("getApplicationVersionDetails", () => {
+    it("should return application version details", async () => {
       const versionDetails = {
-        application_id: 'app1',
-        version_number: 'v1.0.0',
-        name: 'Test Application',
-        description: 'Test description',
-        created_at: '2023-01-01T00:00:00Z',
+        application_id: "app1",
+        version_number: "v1.0.0",
+        name: "Test Application",
+        description: "Test description",
+        created_at: "2023-01-01T00:00:00Z",
       };
-      platformSDKMock.getApplicationVersionDetails.mockResolvedValue(versionDetails);
-
-      await getApplicationVersionDetails('production', mockAuthService, 'app1', 'v1.0.0');
-
-      expect(platformSDKMock.getApplicationVersionDetails).toHaveBeenCalledWith('app1', 'v1.0.0');
-      expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Application version details for app1 vv1.0.0:',
-        JSON.stringify(versionDetails, null, 2)
+      platformSDKMock.getApplicationVersionDetails.mockResolvedValue(
+        versionDetails,
       );
+
+      const result = await getApplicationVersionDetails(
+        "production",
+        mockAuthService,
+        "app1",
+        "v1.0.0",
+      );
+
+      expect(platformSDKMock.getApplicationVersionDetails).toHaveBeenCalledWith(
+        "app1",
+        "v1.0.0",
+      );
+      expect(result).toEqual(versionDetails);
     });
 
-    it('should handle API error', async () => {
-      platformSDKMock.getApplicationVersionDetails.mockRejectedValue(new Error('API error'));
+    it("should handle API error", async () => {
+      platformSDKMock.getApplicationVersionDetails.mockRejectedValue(
+        new Error("API error"),
+      );
 
-      await getApplicationVersionDetails('production', mockAuthService, 'app1', 'v1.0.0');
+      await getApplicationVersionDetails(
+        "production",
+        mockAuthService,
+        "app1",
+        "v1.0.0",
+      );
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Failed to get application version details:',
-        expect.any(Error)
+        "❌ Failed to get application version details:",
+        expect.any(Error),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
   });
 
-  describe('getApplicationDetails', () => {
-    it('should get application details successfully', async () => {
+  describe("getApplicationDetails", () => {
+    it("should return application details", async () => {
       const applicationResponse = {
-        application_id: 'app1',
-        name: 'Test Application',
-        versions: [{ version_number: 'v1.0.0', created_at: '2023-01-01T00:00:00Z' }],
-      };
-      platformSDKMock.getApplication.mockResolvedValue(applicationResponse);
-
-      await getApplicationDetails('production', mockAuthService, 'app1');
-
-      expect(platformSDKMock.getApplication).toHaveBeenCalledWith('app1');
-      expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Application details for app1:',
-        JSON.stringify(applicationResponse, null, 2)
-      );
-    });
-
-    it('should handle API error', async () => {
-      platformSDKMock.getApplication.mockRejectedValue(new Error('API error'));
-
-      await getApplicationDetails('production', mockAuthService, 'app1');
-
-      expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Failed to get application details:',
-        expect.any(Error)
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
-  });
-
-  describe('listApplicationVersions', () => {
-    it('should list application versions successfully', async () => {
-      const applicationResponse = {
-        application_id: 'app1',
-        name: 'Test Application',
+        application_id: "app1",
+        name: "Test Application",
         versions: [
-          { version_number: 'v1.0.0', created_at: '2023-01-01T00:00:00Z' },
-          { version_number: 'v1.1.0', created_at: '2023-02-01T00:00:00Z' },
+          { version_number: "v1.0.0", created_at: "2023-01-01T00:00:00Z" },
         ],
       };
       platformSDKMock.getApplication.mockResolvedValue(applicationResponse);
 
-      await listApplicationVersions('production', mockAuthService, 'app1');
-
-      expect(platformSDKMock.getApplication).toHaveBeenCalledWith('app1');
-      expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Application versions for app1:',
-        JSON.stringify(applicationResponse.versions, null, 2)
+      const result = await getApplicationDetails(
+        "production",
+        mockAuthService,
+        "app1",
       );
+
+      expect(platformSDKMock.getApplication).toHaveBeenCalledWith("app1");
+      expect(result).toEqual(applicationResponse);
     });
 
-    it('should handle API error', async () => {
-      platformSDKMock.getApplication.mockRejectedValue(new Error('API error'));
+    it("should handle API error", async () => {
+      platformSDKMock.getApplication.mockRejectedValue(new Error("API error"));
 
-      await listApplicationVersions('production', mockAuthService, 'app1');
+      await getApplicationDetails("production", mockAuthService, "app1");
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Failed to list application versions:',
-        expect.any(Error)
+        "❌ Failed to get application details:",
+        expect.any(Error),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
   });
 
-  describe('listApplicationRuns', () => {
-    it('should list application runs successfully', async () => {
-      const runsResponse = [
-        {
-          application_run_id: 'run-1',
-          application_version_id: 'v1.0.0',
-          organization_id: 'org-1',
-          status: 'COMPLETED',
-          created_at: '2023-01-01T00:00:00Z',
-          updated_at: '2023-01-01T01:00:00Z',
-        },
-      ];
-      platformSDKMock.listApplicationRuns.mockResolvedValue(runsResponse);
+  describe("listApplicationVersions", () => {
+    it("should return the application versions", async () => {
+      const applicationResponse = {
+        application_id: "app1",
+        name: "Test Application",
+        versions: [
+          { version_number: "v1.0.0", created_at: "2023-01-01T00:00:00Z" },
+          { version_number: "v1.1.0", created_at: "2023-02-01T00:00:00Z" },
+        ],
+      };
+      platformSDKMock.getApplication.mockResolvedValue(applicationResponse);
 
-      await listApplicationRuns('production', mockAuthService);
-
-      expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Application runs:',
-        JSON.stringify(runsResponse, null, 2)
+      const result = await listApplicationVersions(
+        "production",
+        mockAuthService,
+        "app1",
       );
+
+      expect(platformSDKMock.getApplication).toHaveBeenCalledWith("app1");
+      expect(result).toEqual(applicationResponse.versions);
     });
 
-    it('should list application runs with filters', async () => {
+    it("should handle API error", async () => {
+      platformSDKMock.getApplication.mockRejectedValue(new Error("API error"));
+
+      await listApplicationVersions("production", mockAuthService, "app1");
+
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        "❌ Failed to list application versions:",
+        expect.any(Error),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("listApplicationRuns", () => {
+    it("should return the list of application runs", async () => {
       const runsResponse = [
         {
-          application_run_id: 'run-1',
-          application_version_id: 'v1.0.0',
-          organization_id: 'org-1',
-          status: 'COMPLETED',
-          created_at: '2023-01-01T00:00:00Z',
-          updated_at: '2023-01-01T01:00:00Z',
+          application_run_id: "run-1",
+          application_version_id: "v1.0.0",
+          organization_id: "org-1",
+          status: "COMPLETED",
+          created_at: "2023-01-01T00:00:00Z",
+          updated_at: "2023-01-01T01:00:00Z",
         },
       ];
       platformSDKMock.listApplicationRuns.mockResolvedValue(runsResponse);
 
-      await listApplicationRuns('production', mockAuthService, {
-        applicationId: 'app1',
-        applicationVersion: 'v1.0.0',
+      const result = await listApplicationRuns("production", mockAuthService);
+
+      expect(result).toEqual(runsResponse);
+    });
+
+    it("should list application runs with filters", async () => {
+      const runsResponse = [
+        {
+          application_run_id: "run-1",
+          application_version_id: "v1.0.0",
+          organization_id: "org-1",
+          status: "COMPLETED",
+          created_at: "2023-01-01T00:00:00Z",
+          updated_at: "2023-01-01T01:00:00Z",
+        },
+      ];
+      platformSDKMock.listApplicationRuns.mockResolvedValue(runsResponse);
+
+      const result = await listApplicationRuns("production", mockAuthService, {
+        applicationId: "app1",
+        applicationVersion: "v1.0.0",
       });
 
       expect(platformSDKMock.listApplicationRuns).toHaveBeenCalledWith({
-        applicationId: 'app1',
-        applicationVersion: 'v1.0.0',
+        applicationId: "app1",
+        applicationVersion: "v1.0.0",
       });
-      expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Application runs:',
-        JSON.stringify(runsResponse, null, 2)
-      );
+      expect(result).toEqual(runsResponse);
     });
 
-    it('should list application runs with custom metadata filter', async () => {
+    it("should list application runs with custom metadata filter", async () => {
       const runsResponse = [
         {
-          application_run_id: 'run-1',
-          application_version_id: 'v1.0.0',
-          organization_id: 'org-1',
-          status: 'COMPLETED',
-          created_at: '2023-01-01T00:00:00Z',
-          updated_at: '2023-01-01T01:00:00Z',
+          application_run_id: "run-1",
+          application_version_id: "v1.0.0",
+          organization_id: "org-1",
+          status: "COMPLETED",
+          created_at: "2023-01-01T00:00:00Z",
+          updated_at: "2023-01-01T01:00:00Z",
         },
       ];
       platformSDKMock.listApplicationRuns.mockResolvedValue(runsResponse);
 
-      await listApplicationRuns('production', mockAuthService, {
-        applicationId: 'app1',
+      const result = await listApplicationRuns("production", mockAuthService, {
+        applicationId: "app1",
         customMetadata: '{"key": "value"}',
       });
 
       expect(platformSDKMock.listApplicationRuns).toHaveBeenCalledWith({
-        applicationId: 'app1',
+        applicationId: "app1",
         customMetadata: '{"key": "value"}',
       });
-      expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Application runs:',
-        JSON.stringify(runsResponse, null, 2)
-      );
+      expect(result).toEqual(runsResponse);
     });
 
-    it('should list application runs with sort parameter', async () => {
+    it("should list application runs with sort parameter", async () => {
       const runsResponse = [
         {
-          application_run_id: 'run-1',
-          application_version_id: 'v1.0.0',
-          organization_id: 'org-1',
-          status: 'COMPLETED',
-          created_at: '2023-01-01T00:00:00Z',
-          updated_at: '2023-01-01T01:00:00Z',
+          application_run_id: "run-1",
+          application_version_id: "v1.0.0",
+          organization_id: "org-1",
+          status: "COMPLETED",
+          created_at: "2023-01-01T00:00:00Z",
+          updated_at: "2023-01-01T01:00:00Z",
         },
       ];
       platformSDKMock.listApplicationRuns.mockResolvedValue(runsResponse);
 
-      await listApplicationRuns('production', mockAuthService, {
+      const result = await listApplicationRuns("production", mockAuthService, {
         sort: '["created_at", "-updated_at"]',
       });
 
       expect(platformSDKMock.listApplicationRuns).toHaveBeenCalledWith({
-        sort: ['created_at', '-updated_at'],
+        sort: ["created_at", "-updated_at"],
       });
-      expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Application runs:',
-        JSON.stringify(runsResponse, null, 2)
-      );
+      expect(result).toEqual(runsResponse);
     });
 
-    it('should list application runs with all filters and sort', async () => {
+    it("should list application runs with all filters and sort", async () => {
       const runsResponse = [
         {
-          application_run_id: 'run-1',
-          application_version_id: 'v1.0.0',
-          organization_id: 'org-1',
-          status: 'COMPLETED',
-          created_at: '2023-01-01T00:00:00Z',
-          updated_at: '2023-01-01T01:00:00Z',
+          application_run_id: "run-1",
+          application_version_id: "v1.0.0",
+          organization_id: "org-1",
+          status: "COMPLETED",
+          created_at: "2023-01-01T00:00:00Z",
+          updated_at: "2023-01-01T01:00:00Z",
         },
       ];
       platformSDKMock.listApplicationRuns.mockResolvedValue(runsResponse);
 
-      await listApplicationRuns('production', mockAuthService, {
-        applicationId: 'app1',
-        applicationVersion: 'v1.0.0',
+      const result = await listApplicationRuns("production", mockAuthService, {
+        applicationId: "app1",
+        applicationVersion: "v1.0.0",
         customMetadata: '{"environment": "test"}',
         sort: '["-created_at"]',
       });
 
       expect(platformSDKMock.listApplicationRuns).toHaveBeenCalledWith({
-        applicationId: 'app1',
-        applicationVersion: 'v1.0.0',
+        applicationId: "app1",
+        applicationVersion: "v1.0.0",
         customMetadata: '{"environment": "test"}',
-        sort: ['-created_at'],
+        sort: ["-created_at"],
       });
-      expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Application runs:',
-        JSON.stringify(runsResponse, null, 2)
-      );
+      expect(result).toEqual(runsResponse);
     });
 
-    it('should handle invalid sort JSON', async () => {
-      await listApplicationRuns('production', mockAuthService, {
-        sort: 'invalid-json',
+    it("should handle invalid sort JSON", async () => {
+      await listApplicationRuns("production", mockAuthService, {
+        sort: "invalid-json",
       });
 
-      expect(consoleSpy.error).toHaveBeenCalledWith('❌ Invalid sort array:', expect.any(Error));
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        "❌ Invalid sort array:",
+        expect.any(Error),
+      );
       expect(mockExit).toHaveBeenCalledWith(1);
       expect(platformSDKMock.listApplicationRuns).not.toHaveBeenCalled();
     });
 
-    it('should handle empty customMetadata', async () => {
+    it("should handle empty customMetadata", async () => {
       const runsResponse = [
         {
-          application_run_id: 'run-1',
-          application_version_id: 'v1.0.0',
-          organization_id: 'org-1',
-          status: 'COMPLETED',
-          created_at: '2023-01-01T00:00:00Z',
-          updated_at: '2023-01-01T01:00:00Z',
+          application_run_id: "run-1",
+          application_version_id: "v1.0.0",
+          organization_id: "org-1",
+          status: "COMPLETED",
+          created_at: "2023-01-01T00:00:00Z",
+          updated_at: "2023-01-01T01:00:00Z",
         },
       ];
       platformSDKMock.listApplicationRuns.mockResolvedValue(runsResponse);
 
-      await listApplicationRuns('production', mockAuthService, {
-        customMetadata: '{}',
+      const result = await listApplicationRuns("production", mockAuthService, {
+        customMetadata: "{}",
       });
 
       expect(platformSDKMock.listApplicationRuns).toHaveBeenCalledWith({
-        customMetadata: '{}',
+        customMetadata: "{}",
       });
-      expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Application runs:',
-        JSON.stringify(runsResponse, null, 2)
-      );
+      expect(result).toEqual(runsResponse);
     });
 
-    it('should handle empty sort array', async () => {
+    it("should handle empty sort array", async () => {
       const runsResponse = [
         {
-          application_run_id: 'run-1',
-          application_version_id: 'v1.0.0',
-          organization_id: 'org-1',
-          status: 'COMPLETED',
-          created_at: '2023-01-01T00:00:00Z',
-          updated_at: '2023-01-01T01:00:00Z',
+          application_run_id: "run-1",
+          application_version_id: "v1.0.0",
+          organization_id: "org-1",
+          status: "COMPLETED",
+          created_at: "2023-01-01T00:00:00Z",
+          updated_at: "2023-01-01T01:00:00Z",
         },
       ];
       platformSDKMock.listApplicationRuns.mockResolvedValue(runsResponse);
 
-      await listApplicationRuns('production', mockAuthService, {
-        sort: '[]',
+      const result = await listApplicationRuns("production", mockAuthService, {
+        sort: "[]",
       });
 
       expect(platformSDKMock.listApplicationRuns).toHaveBeenCalledWith({
         sort: [],
       });
-      expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Application runs:',
-        JSON.stringify(runsResponse, null, 2)
-      );
+      expect(result).toEqual(runsResponse);
     });
 
-    it('should handle API error', async () => {
-      platformSDKMock.listApplicationRuns.mockRejectedValue(new Error('API error'));
+    it("should handle API error", async () => {
+      platformSDKMock.listApplicationRuns.mockRejectedValue(
+        new Error("API error"),
+      );
 
-      await listApplicationRuns('production', mockAuthService);
+      await listApplicationRuns("production", mockAuthService);
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Failed to list application runs:',
-        expect.any(Error)
+        "❌ Failed to list application runs:",
+        expect.any(Error),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
 
-    it('should handle API error with filters', async () => {
-      platformSDKMock.listApplicationRuns.mockRejectedValue(new Error('Network error'));
+    it("should handle API error with filters", async () => {
+      platformSDKMock.listApplicationRuns.mockRejectedValue(
+        new Error("Network error"),
+      );
 
-      await listApplicationRuns('production', mockAuthService, {
-        applicationId: 'app1',
+      await listApplicationRuns("production", mockAuthService, {
+        applicationId: "app1",
         customMetadata: '{"key": "value"}',
         sort: '["-created_at"]',
       });
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Failed to list application runs:',
-        expect.any(Error)
+        "❌ Failed to list application runs:",
+        expect.any(Error),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
   });
 
-  describe('getRun', () => {
-    it('should get run details successfully', async () => {
+  describe("getRun", () => {
+    it("should return the run details", async () => {
       const runResponse = {
-        application_run_id: 'run-1',
-        application_version_id: 'v1.0.0',
-        organization_id: 'org-1',
-        status: 'COMPLETED',
-        created_at: '2023-01-01T00:00:00Z',
-        updated_at: '2023-01-01T01:00:00Z',
+        application_run_id: "run-1",
+        application_version_id: "v1.0.0",
+        organization_id: "org-1",
+        status: "COMPLETED",
+        created_at: "2023-01-01T00:00:00Z",
+        updated_at: "2023-01-01T01:00:00Z",
       };
       platformSDKMock.getRun.mockResolvedValue(runResponse);
 
-      await getRun('production', mockAuthService, 'run-1');
+      const result = await getRun("production", mockAuthService, "run-1");
 
-      expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Run details for run-1:',
-        JSON.stringify(runResponse, null, 2)
-      );
+      expect(result).toEqual(runResponse);
     });
 
-    it('should handle API error', async () => {
-      platformSDKMock.getRun.mockRejectedValue(new Error('API error'));
+    it("should handle API error", async () => {
+      platformSDKMock.getRun.mockRejectedValue(new Error("API error"));
 
-      await getRun('production', mockAuthService, 'run-1');
-
-      expect(consoleSpy.error).toHaveBeenCalledWith('❌ Failed to get run:', expect.any(Error));
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
-  });
-
-  describe('cancelApplicationRun', () => {
-    it('should cancel application run successfully', async () => {
-      platformSDKMock.cancelApplicationRun.mockResolvedValue(undefined);
-
-      await cancelApplicationRun('production', mockAuthService, 'run-1');
-
-      expect(consoleSpy.log).toHaveBeenCalledWith(
-        '✅ Successfully cancelled application run: run-1'
-      );
-    });
-
-    it('should handle API error', async () => {
-      platformSDKMock.cancelApplicationRun.mockRejectedValue(new Error('API error'));
-
-      await cancelApplicationRun('production', mockAuthService, 'run-1');
+      await getRun("production", mockAuthService, "run-1");
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Failed to cancel application run:',
-        expect.any(Error)
+        "❌ Failed to get run:",
+        expect.any(Error),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
   });
 
-  describe('listRunResults', () => {
-    it('should list run results successfully', async () => {
+  describe("cancelApplicationRun", () => {
+    it("should cancel application run successfully", async () => {
+      platformSDKMock.cancelApplicationRun.mockResolvedValue(undefined);
+
+      await cancelApplicationRun("production", mockAuthService, "run-1");
+
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        "✅ Successfully cancelled application run: run-1",
+      );
+    });
+
+    it("should handle API error", async () => {
+      platformSDKMock.cancelApplicationRun.mockRejectedValue(
+        new Error("API error"),
+      );
+
+      await cancelApplicationRun("production", mockAuthService, "run-1");
+
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        "❌ Failed to cancel application run:",
+        expect.any(Error),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("listRunResults", () => {
+    it("should return the run results", async () => {
       const resultsResponse = [
         {
-          item_id: 'item-1',
-          reference: 'test-ref-1',
-          status: 'SUCCEEDED',
+          item_id: "item-1",
+          reference: "test-ref-1",
+          status: "SUCCEEDED",
           input_artifacts: [],
           output_artifacts: [],
-          created_at: '2023-01-01T00:00:00Z',
-          updated_at: '2023-01-01T01:00:00Z',
+          created_at: "2023-01-01T00:00:00Z",
+          updated_at: "2023-01-01T01:00:00Z",
         },
       ];
       platformSDKMock.listRunResults.mockResolvedValue(resultsResponse);
 
-      await listRunResults('production', mockAuthService, 'run-1');
-
-      expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Run results for run-1:',
-        JSON.stringify(resultsResponse, null, 2)
+      const result = await listRunResults(
+        "production",
+        mockAuthService,
+        "run-1",
       );
+
+      expect(result).toEqual(resultsResponse);
     });
 
-    it('should handle API error', async () => {
-      platformSDKMock.listRunResults.mockRejectedValue(new Error('API error'));
+    it("should handle API error", async () => {
+      platformSDKMock.listRunResults.mockRejectedValue(new Error("API error"));
 
-      await listRunResults('production', mockAuthService, 'run-1');
+      await listRunResults("production", mockAuthService, "run-1");
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Failed to list run results:',
-        expect.any(Error)
+        "❌ Failed to list run results:",
+        expect.any(Error),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
   });
 
-  describe('getRunItem', () => {
-    it('should get a single run item successfully', async () => {
+  describe("getRunItem", () => {
+    it("should get a single run item successfully", async () => {
       const itemResponse = {
-        item_id: 'item-1',
-        external_id: 'ext-1',
-        status: 'SUCCEEDED',
+        item_id: "item-1",
+        external_id: "ext-1",
+        status: "SUCCEEDED",
         input_artifacts: [],
         output_artifacts: [],
       };
       platformSDKMock.getRunItem.mockResolvedValue(itemResponse);
 
-      await getRunItem('production', mockAuthService, 'run-1', 'ext-1');
+      await getRunItem("production", mockAuthService, "run-1", "ext-1");
 
-      expect(platformSDKMock.getRunItem).toHaveBeenCalledWith('run-1', 'ext-1');
+      expect(platformSDKMock.getRunItem).toHaveBeenCalledWith("run-1", "ext-1");
       expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Run item details for run-1/ext-1:',
-        JSON.stringify(itemResponse, null, 2)
+        "Run item details for run-1/ext-1:",
+        JSON.stringify(itemResponse, null, 2),
       );
     });
 
-    it('should handle API error', async () => {
-      platformSDKMock.getRunItem.mockRejectedValue(new Error('API error'));
+    it("should handle API error", async () => {
+      platformSDKMock.getRunItem.mockRejectedValue(new Error("API error"));
 
-      await getRunItem('production', mockAuthService, 'run-1', 'ext-1');
+      await getRunItem("production", mockAuthService, "run-1", "ext-1");
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Failed to get run item:',
-        expect.any(Error)
+        "❌ Failed to get run item:",
+        expect.any(Error),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
   });
 
-  describe('updateRunMetadata', () => {
-    it('should update run custom metadata successfully', async () => {
-      const updateResponse = { custom_metadata_checksum: 'abc123' };
+  describe("updateRunMetadata", () => {
+    it("should update run custom metadata successfully", async () => {
+      const updateResponse = { custom_metadata_checksum: "abc123" };
       platformSDKMock.updateRunMetadata.mockResolvedValue(updateResponse);
 
-      await updateRunMetadata('production', mockAuthService, 'run-1', '{"note":"reviewed"}');
+      await updateRunMetadata(
+        "production",
+        mockAuthService,
+        "run-1",
+        '{"note":"reviewed"}',
+      );
 
-      expect(platformSDKMock.updateRunMetadata).toHaveBeenCalledWith('run-1', { note: 'reviewed' });
+      expect(platformSDKMock.updateRunMetadata).toHaveBeenCalledWith("run-1", {
+        note: "reviewed",
+      });
       expect(consoleSpy.log).toHaveBeenCalledWith(
-        '✅ Updated custom metadata for run run-1:',
-        JSON.stringify(updateResponse, null, 2)
+        "✅ Updated custom metadata for run run-1:",
+        JSON.stringify(updateResponse, null, 2),
       );
     });
 
-    it('should support clearing metadata with null', async () => {
+    it("should support clearing metadata with null", async () => {
       const updateResponse = { custom_metadata_checksum: null };
       platformSDKMock.updateRunMetadata.mockResolvedValue(updateResponse);
 
-      await updateRunMetadata('production', mockAuthService, 'run-1', 'null');
+      await updateRunMetadata("production", mockAuthService, "run-1", "null");
 
-      expect(platformSDKMock.updateRunMetadata).toHaveBeenCalledWith('run-1', null);
+      expect(platformSDKMock.updateRunMetadata).toHaveBeenCalledWith(
+        "run-1",
+        null,
+      );
     });
 
-    it('should handle invalid custom metadata JSON', async () => {
-      await updateRunMetadata('production', mockAuthService, 'run-1', 'not-json');
+    it("should handle invalid custom metadata JSON", async () => {
+      await updateRunMetadata(
+        "production",
+        mockAuthService,
+        "run-1",
+        "not-json",
+      );
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Invalid custom metadata JSON:',
-        expect.any(Error)
+        "❌ Invalid custom metadata JSON:",
+        expect.any(Error),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
       expect(platformSDKMock.updateRunMetadata).not.toHaveBeenCalled();
     });
 
-    it('should handle non-object custom metadata JSON', async () => {
-      await updateRunMetadata('production', mockAuthService, 'run-1', '"just a string"');
+    it("should handle non-object custom metadata JSON", async () => {
+      await updateRunMetadata(
+        "production",
+        mockAuthService,
+        "run-1",
+        '"just a string"',
+      );
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Invalid custom metadata JSON:',
-        expect.any(TypeError)
+        "❌ Invalid custom metadata JSON:",
+        expect.any(TypeError),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
       expect(platformSDKMock.updateRunMetadata).not.toHaveBeenCalled();
     });
 
-    it('should handle API error', async () => {
-      platformSDKMock.updateRunMetadata.mockRejectedValue(new Error('API error'));
+    it("should handle API error", async () => {
+      platformSDKMock.updateRunMetadata.mockRejectedValue(
+        new Error("API error"),
+      );
 
-      await updateRunMetadata('production', mockAuthService, 'run-1', '{}');
+      await updateRunMetadata("production", mockAuthService, "run-1", "{}");
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Failed to update run metadata:',
-        expect.any(Error)
+        "❌ Failed to update run metadata:",
+        expect.any(Error),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
   });
 
-  describe('updateRunItemMetadata', () => {
-    it('should update run item custom metadata successfully', async () => {
-      const updateResponse = { custom_metadata_checksum: 'abc123' };
+  describe("updateRunItemMetadata", () => {
+    it("should update run item custom metadata successfully", async () => {
+      const updateResponse = { custom_metadata_checksum: "abc123" };
       platformSDKMock.updateRunItemMetadata.mockResolvedValue(updateResponse);
 
       await updateRunItemMetadata(
-        'production',
+        "production",
         mockAuthService,
-        'run-1',
-        'ext-1',
-        '{"reviewed":true}'
+        "run-1",
+        "ext-1",
+        '{"reviewed":true}',
       );
 
-      expect(platformSDKMock.updateRunItemMetadata).toHaveBeenCalledWith('run-1', 'ext-1', {
-        reviewed: true,
-      });
+      expect(platformSDKMock.updateRunItemMetadata).toHaveBeenCalledWith(
+        "run-1",
+        "ext-1",
+        {
+          reviewed: true,
+        },
+      );
       expect(consoleSpy.log).toHaveBeenCalledWith(
-        '✅ Updated custom metadata for item run-1/ext-1:',
-        JSON.stringify(updateResponse, null, 2)
+        "✅ Updated custom metadata for item run-1/ext-1:",
+        JSON.stringify(updateResponse, null, 2),
       );
     });
 
-    it('should handle invalid custom metadata JSON', async () => {
-      await updateRunItemMetadata('production', mockAuthService, 'run-1', 'ext-1', 'not-json');
+    it("should handle invalid custom metadata JSON", async () => {
+      await updateRunItemMetadata(
+        "production",
+        mockAuthService,
+        "run-1",
+        "ext-1",
+        "not-json",
+      );
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Invalid custom metadata JSON:',
-        expect.any(Error)
+        "❌ Invalid custom metadata JSON:",
+        expect.any(Error),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
       expect(platformSDKMock.updateRunItemMetadata).not.toHaveBeenCalled();
     });
 
-    it('should handle API error', async () => {
-      platformSDKMock.updateRunItemMetadata.mockRejectedValue(new Error('API error'));
+    it("should handle API error", async () => {
+      platformSDKMock.updateRunItemMetadata.mockRejectedValue(
+        new Error("API error"),
+      );
 
-      await updateRunItemMetadata('production', mockAuthService, 'run-1', 'ext-1', '{}');
+      await updateRunItemMetadata(
+        "production",
+        mockAuthService,
+        "run-1",
+        "ext-1",
+        "{}",
+      );
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Failed to update run item metadata:',
-        expect.any(Error)
+        "❌ Failed to update run item metadata:",
+        expect.any(Error),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
   });
-  describe('createGrant', () => {
-    it('should create a grant successfully', async () => {
+  describe("createGrant", () => {
+    it("should create a grant successfully", async () => {
       const grantResponse = {
-        grant_id: 'grant-1',
-        resource_type: 'run',
-        resource_id: 'run-1',
-        subject_type: 'user',
-        subject_id: 'user-1',
-        relation: 'viewer',
-        created_by: 'user-2',
-        created_at: '2023-01-01T00:00:00Z',
+        grant_id: "grant-1",
+        resource_type: "run",
+        resource_id: "run-1",
+        subject_type: "user",
+        subject_id: "user-1",
+        relation: "viewer",
+        created_by: "user-2",
+        created_at: "2023-01-01T00:00:00Z",
         revoked: false,
       };
       platformSDKMock.createGrant.mockResolvedValue(grantResponse);
 
-      await createGrant('production', mockAuthService, {
-        resourceType: 'run',
-        resourceId: 'run-1',
-        subjectType: 'user',
-        subjectEmail: 'colleague@example.com',
-        relation: 'viewer',
+      const result = await createGrant("production", mockAuthService, {
+        resourceType: "run",
+        resourceId: "run-1",
+        subjectType: "user",
+        subjectEmail: "colleague@example.com",
+        relation: "viewer",
       });
 
       expect(platformSDKMock.createGrant).toHaveBeenCalledWith({
-        resource_type: 'run',
-        resource_id: 'run-1',
-        subject_type: 'user',
+        resource_type: "run",
+        resource_id: "run-1",
+        subject_type: "user",
         subject_id: undefined,
-        subject_email: 'colleague@example.com',
-        relation: 'viewer',
+        subject_email: "colleague@example.com",
+        relation: "viewer",
       });
-      expect(consoleSpy.log).toHaveBeenCalledWith(
-        '✅ Grant created successfully:',
-        JSON.stringify(grantResponse, null, 2)
-      );
+      expect(result).toEqual(grantResponse);
     });
 
-    it('should handle API error', async () => {
-      platformSDKMock.createGrant.mockRejectedValue(new Error('API error'));
+    it("should handle API error", async () => {
+      platformSDKMock.createGrant.mockRejectedValue(new Error("API error"));
 
-      await createGrant('production', mockAuthService, {
-        resourceType: 'run',
-        resourceId: 'run-1',
-        subjectType: 'user',
-        relation: 'viewer',
+      await createGrant("production", mockAuthService, {
+        resourceType: "run",
+        resourceId: "run-1",
+        subjectType: "user",
+        relation: "viewer",
       });
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Failed to create grant:',
-        expect.any(Error)
+        "❌ Failed to create grant:",
+        expect.any(Error),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
   });
 
-  describe('deleteRunResults', () => {
-    it('should delete run results successfully', async () => {
+  describe("deleteRunResults", () => {
+    it("should delete run results successfully", async () => {
       platformSDKMock.deleteRunResults.mockResolvedValue(undefined);
 
-      await deleteRunResults('production', mockAuthService, 'run-1');
+      await deleteRunResults("production", mockAuthService, "run-1");
 
-      expect(platformSDKMock.deleteRunResults).toHaveBeenCalledWith('run-1');
-      expect(consoleSpy.log).toHaveBeenCalledWith('✅ Successfully deleted results for run: run-1');
+      expect(platformSDKMock.deleteRunResults).toHaveBeenCalledWith("run-1");
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        "✅ Successfully deleted results for run: run-1",
+      );
     });
 
-    it('should handle API error', async () => {
-      platformSDKMock.deleteRunResults.mockRejectedValue(new Error('API error'));
+    it("should handle API error", async () => {
+      platformSDKMock.deleteRunResults.mockRejectedValue(
+        new Error("API error"),
+      );
 
-      await deleteRunResults('production', mockAuthService, 'run-1');
+      await deleteRunResults("production", mockAuthService, "run-1");
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Failed to delete run results:',
-        expect.any(Error)
+        "❌ Failed to delete run results:",
+        expect.any(Error),
       );
     });
   });
 
-  describe('listGrants', () => {
-    it('should list grants successfully', async () => {
+  describe("listGrants", () => {
+    it("should list grants successfully", async () => {
       const grantsResponse = [
         {
-          grant_id: 'grant-1',
-          resource_type: 'run',
-          resource_id: 'run-1',
-          subject_type: 'user',
-          subject_id: 'user-1',
-          relation: 'viewer',
-          created_by: 'user-2',
-          created_at: '2023-01-01T00:00:00Z',
+          grant_id: "grant-1",
+          resource_type: "run",
+          resource_id: "run-1",
+          subject_type: "user",
+          subject_id: "user-1",
+          relation: "viewer",
+          created_by: "user-2",
+          created_at: "2023-01-01T00:00:00Z",
           revoked: false,
         },
       ];
       platformSDKMock.listGrants.mockResolvedValue(grantsResponse);
 
-      await listGrants('production', mockAuthService, { resourceId: 'run-1' });
+      const result = await listGrants("production", mockAuthService, {
+        resourceId: "run-1",
+      });
 
-      expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Grants:',
-        JSON.stringify(grantsResponse, null, 2)
-      );
+      expect(result).toEqual(grantsResponse);
     });
 
-    it('should handle API error', async () => {
-      platformSDKMock.listGrants.mockRejectedValue(new Error('API error'));
+    it("should handle API error", async () => {
+      platformSDKMock.listGrants.mockRejectedValue(new Error("API error"));
 
-      await listGrants('production', mockAuthService);
+      await listGrants("production", mockAuthService);
 
-      expect(consoleSpy.error).toHaveBeenCalledWith('❌ Failed to list grants:', expect.any(Error));
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        "❌ Failed to list grants:",
+        expect.any(Error),
+      );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
   });
 
-  describe('getGrant', () => {
-    it('should get grant details successfully', async () => {
+  describe("getGrant", () => {
+    it("should get grant details successfully", async () => {
       const grantResponse = {
-        grant_id: 'grant-1',
-        resource_type: 'run',
-        resource_id: 'run-1',
-        subject_type: 'user',
-        subject_id: 'user-1',
-        relation: 'viewer',
-        created_by: 'user-2',
-        created_at: '2023-01-01T00:00:00Z',
+        grant_id: "grant-1",
+        resource_type: "run",
+        resource_id: "run-1",
+        subject_type: "user",
+        subject_id: "user-1",
+        relation: "viewer",
+        created_by: "user-2",
+        created_at: "2023-01-01T00:00:00Z",
         revoked: false,
       };
       platformSDKMock.getGrant.mockResolvedValue(grantResponse);
 
-      await getGrant('production', mockAuthService, 'grant-1');
+      const result = await getGrant("production", mockAuthService, "grant-1");
 
-      expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Grant details for grant-1:',
-        JSON.stringify(grantResponse, null, 2)
-      );
+      expect(result).toEqual(grantResponse);
     });
 
-    it('should handle API error', async () => {
-      platformSDKMock.getGrant.mockRejectedValue(new Error('API error'));
+    it("should handle API error", async () => {
+      platformSDKMock.getGrant.mockRejectedValue(new Error("API error"));
 
-      await getGrant('production', mockAuthService, 'grant-1');
+      await getGrant("production", mockAuthService, "grant-1");
 
-      expect(consoleSpy.error).toHaveBeenCalledWith('❌ Failed to get grant:', expect.any(Error));
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        "❌ Failed to get grant:",
+        expect.any(Error),
+      );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
   });
 
-  describe('revokeGrant', () => {
-    it('should revoke a grant successfully', async () => {
+  describe("revokeGrant", () => {
+    it("should revoke a grant successfully", async () => {
       const grantResponse = {
-        grant_id: 'grant-1',
-        resource_type: 'run',
-        resource_id: 'run-1',
-        subject_type: 'user',
-        subject_id: 'user-1',
-        relation: 'viewer',
-        created_by: 'user-2',
-        created_at: '2023-01-01T00:00:00Z',
+        grant_id: "grant-1",
+        resource_type: "run",
+        resource_id: "run-1",
+        subject_type: "user",
+        subject_id: "user-1",
+        relation: "viewer",
+        created_by: "user-2",
+        created_at: "2023-01-01T00:00:00Z",
         revoked: true,
       };
       platformSDKMock.revokeGrant.mockResolvedValue(grantResponse);
 
-      await revokeGrant('production', mockAuthService, 'grant-1');
-
-      expect(consoleSpy.log).toHaveBeenCalledWith(
-        '✅ Grant revoked successfully:',
-        JSON.stringify(grantResponse, null, 2)
+      const result = await revokeGrant(
+        "production",
+        mockAuthService,
+        "grant-1",
       );
+
+      expect(result).toEqual(grantResponse);
     });
 
-    it('should handle API error', async () => {
-      platformSDKMock.revokeGrant.mockRejectedValue(new Error('API error'));
+    it("should handle API error", async () => {
+      platformSDKMock.revokeGrant.mockRejectedValue(new Error("API error"));
 
-      await revokeGrant('production', mockAuthService, 'grant-1');
+      await revokeGrant("production", mockAuthService, "grant-1");
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Failed to revoke grant:',
-        expect.any(Error)
+        "❌ Failed to revoke grant:",
+        expect.any(Error),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
   });
 
-  describe('createShareToken', () => {
-    it('should create a share token successfully', async () => {
+  describe("createShareToken", () => {
+    it("should create a share token successfully", async () => {
       const shareTokenResponse = {
-        share_token_id: 'share-token-1',
-        share_token: 'secret-value',
-        created_at: '2023-01-01T00:00:00Z',
+        share_token_id: "share-token-1",
+        share_token: "secret-value",
+        created_at: "2023-01-01T00:00:00Z",
         expires_at: null,
         revoked: false,
       };
       platformSDKMock.createShareToken.mockResolvedValue(shareTokenResponse);
 
-      await createShareToken('production', mockAuthService, { expiresAt: '2026-01-01T00:00:00Z' });
+      const result = await createShareToken("production", mockAuthService, {
+        expiresAt: "2026-01-01T00:00:00Z",
+      });
 
       expect(platformSDKMock.createShareToken).toHaveBeenCalledWith({
-        expires_at: '2026-01-01T00:00:00Z',
+        expires_at: "2026-01-01T00:00:00Z",
       });
-      expect(consoleSpy.log).toHaveBeenCalledWith(
-        '✅ Share token created successfully:',
-        JSON.stringify(shareTokenResponse, null, 2)
-      );
-      expect(consoleSpy.log).toHaveBeenCalledWith(
-        '⚠️  Save the share_token value now — it will not be shown again.'
+      expect(result).toEqual(shareTokenResponse);
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        "⚠️  Save the share_token value now — it will not be shown again.",
       );
     });
 
-    it('should handle API error', async () => {
-      platformSDKMock.createShareToken.mockRejectedValue(new Error('API error'));
+    it("should handle API error", async () => {
+      platformSDKMock.createShareToken.mockRejectedValue(
+        new Error("API error"),
+      );
 
-      await createShareToken('production', mockAuthService);
+      await createShareToken("production", mockAuthService);
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Failed to create share token:',
-        expect.any(Error)
+        "❌ Failed to create share token:",
+        expect.any(Error),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
   });
 
-  describe('listShareTokens', () => {
-    it('should list share tokens successfully', async () => {
+  describe("listShareTokens", () => {
+    it("should list share tokens successfully", async () => {
       const shareTokensResponse = [
         {
-          share_token_id: 'share-token-1',
-          created_at: '2023-01-01T00:00:00Z',
+          share_token_id: "share-token-1",
+          created_at: "2023-01-01T00:00:00Z",
           expires_at: null,
           revoked: false,
         },
       ];
       platformSDKMock.listShareTokens.mockResolvedValue(shareTokensResponse);
 
-      await listShareTokens('production', mockAuthService, { runId: 'run-1' });
+      const result = await listShareTokens("production", mockAuthService, {
+        runId: "run-1",
+      });
 
-      expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Share tokens:',
-        JSON.stringify(shareTokensResponse, null, 2)
-      );
+      expect(result).toEqual(shareTokensResponse);
     });
 
-    it('should handle API error', async () => {
-      platformSDKMock.listShareTokens.mockRejectedValue(new Error('API error'));
+    it("should handle API error", async () => {
+      platformSDKMock.listShareTokens.mockRejectedValue(new Error("API error"));
 
-      await listShareTokens('production', mockAuthService);
+      await listShareTokens("production", mockAuthService);
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Failed to list share tokens:',
-        expect.any(Error)
+        "❌ Failed to list share tokens:",
+        expect.any(Error),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
   });
 
-  describe('getShareToken', () => {
-    it('should get share token details successfully', async () => {
+  describe("getShareToken", () => {
+    it("should get share token details successfully", async () => {
       const shareTokenResponse = {
-        share_token_id: 'share-token-1',
-        created_at: '2023-01-01T00:00:00Z',
+        share_token_id: "share-token-1",
+        created_at: "2023-01-01T00:00:00Z",
         expires_at: null,
         revoked: false,
       };
       platformSDKMock.getShareToken.mockResolvedValue(shareTokenResponse);
 
-      await getShareToken('production', mockAuthService, 'share-token-1');
-
-      expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Share token details for share-token-1:',
-        JSON.stringify(shareTokenResponse, null, 2)
+      const result = await getShareToken(
+        "production",
+        mockAuthService,
+        "share-token-1",
       );
+
+      expect(result).toEqual(shareTokenResponse);
     });
 
-    it('should handle API error', async () => {
-      platformSDKMock.getShareToken.mockRejectedValue(new Error('API error'));
+    it("should handle API error", async () => {
+      platformSDKMock.getShareToken.mockRejectedValue(new Error("API error"));
 
-      await getShareToken('production', mockAuthService, 'share-token-1');
+      await getShareToken("production", mockAuthService, "share-token-1");
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Failed to get share token:',
-        expect.any(Error)
+        "❌ Failed to get share token:",
+        expect.any(Error),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
   });
 
-  describe('revokeShareToken', () => {
-    it('should revoke a share token successfully', async () => {
+  describe("revokeShareToken", () => {
+    it("should revoke a share token successfully", async () => {
       const shareTokenResponse = {
-        share_token_id: 'share-token-1',
-        created_at: '2023-01-01T00:00:00Z',
+        share_token_id: "share-token-1",
+        created_at: "2023-01-01T00:00:00Z",
         expires_at: null,
         revoked: true,
       };
       platformSDKMock.revokeShareToken.mockResolvedValue(shareTokenResponse);
 
-      await revokeShareToken('production', mockAuthService, 'share-token-1');
-
-      expect(consoleSpy.log).toHaveBeenCalledWith(
-        '✅ Share token revoked successfully:',
-        JSON.stringify(shareTokenResponse, null, 2)
+      const result = await revokeShareToken(
+        "production",
+        mockAuthService,
+        "share-token-1",
       );
+
+      expect(result).toEqual(shareTokenResponse);
     });
 
-    it('should handle API error', async () => {
-      platformSDKMock.revokeShareToken.mockRejectedValue(new Error('API error'));
+    it("should handle API error", async () => {
+      platformSDKMock.revokeShareToken.mockRejectedValue(
+        new Error("API error"),
+      );
 
-      await revokeShareToken('production', mockAuthService, 'share-token-1');
+      await revokeShareToken("production", mockAuthService, "share-token-1");
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Failed to revoke share token:',
-        expect.any(Error)
+        "❌ Failed to revoke share token:",
+        expect.any(Error),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
   });
 
-  describe('resolveItemsInput', () => {
+  describe("resolveItemsInput", () => {
     let originalIsTTY: boolean | undefined;
 
     beforeEach(() => {
@@ -1094,14 +1177,20 @@ describe('CLI Functions Unit Tests', () => {
       process.stdin.isTTY = originalIsTTY;
     });
 
-    it('should prefer the inline items option', async () => {
-      const result = await resolveItemsInput({ items: '[{"a":1}]', itemsFile: '/tmp/items.json' });
+    it("should prefer the inline items option", async () => {
+      const result = await resolveItemsInput({
+        items: '[{"a":1}]',
+        itemsFile: "/tmp/items.json",
+      });
 
       expect(result).toBe('[{"a":1}]');
     });
 
-    it('should read from the items file when no inline items are given', async () => {
-      const itemsFile = join(tmpdir(), `resolve-items-input-${Date.now()}.json`);
+    it("should read from the items file when no inline items are given", async () => {
+      const itemsFile = join(
+        tmpdir(),
+        `resolve-items-input-${Date.now()}.json`,
+      );
       fs.writeFileSync(itemsFile, '[{"b":2}]');
 
       try {
@@ -1113,13 +1202,13 @@ describe('CLI Functions Unit Tests', () => {
       }
     });
 
-    it('should default to an empty array when running interactively with no options', async () => {
+    it("should default to an empty array when running interactively with no options", async () => {
       const result = await resolveItemsInput({});
 
-      expect(result).toBe('[]');
+      expect(result).toBe("[]");
     });
 
-    it('should read items piped via stdin when no options are given', async () => {
+    it("should read items piped via stdin when no options are given", async () => {
       const stdinStream = Readable.from([
         Buffer.from('[{"c":3}]'),
       ]) as unknown as typeof process.stdin;
@@ -1134,7 +1223,7 @@ describe('CLI Functions Unit Tests', () => {
       process.stdin = originalStdin;
     });
 
-    it('should default to an empty array when stdin is piped but empty', async () => {
+    it("should default to an empty array when stdin is piped but empty", async () => {
       const stdinStream = Readable.from([]) as unknown as typeof process.stdin;
       stdinStream.isTTY = false;
       const originalStdin = process.stdin;
@@ -1142,119 +1231,132 @@ describe('CLI Functions Unit Tests', () => {
 
       const result = await resolveItemsInput({});
 
-      expect(result).toBe('[]');
+      expect(result).toBe("[]");
 
       process.stdin = originalStdin;
     });
   });
 
-  describe('createApplicationRun', () => {
-    it('should create application run successfully with empty items', async () => {
+  describe("createApplicationRun", () => {
+    it("should create application run successfully with empty items", async () => {
       const runResponse = {
-        application_run_id: 'run-123',
+        application_run_id: "run-123",
       };
       platformSDKMock.createApplicationRun.mockResolvedValue(runResponse);
 
-      await createApplicationRun('production', mockAuthService, 'test-app', 'v1.0.0', '[]');
+      const result = await createApplicationRun(
+        "production",
+        mockAuthService,
+        "test-app",
+        "v1.0.0",
+        "[]",
+      );
 
       expect(platformSDKMock.createApplicationRun).toHaveBeenCalledWith({
-        application_id: 'test-app',
-        version_number: 'v1.0.0',
+        application_id: "test-app",
+        version_number: "v1.0.0",
         items: [],
       });
-      expect(consoleSpy.log).toHaveBeenCalledWith(
-        '✅ Application run created successfully:',
-        JSON.stringify(runResponse, null, 2)
-      );
+      expect(result).toEqual(runResponse);
     });
 
-    it('should create application run successfully with items', async () => {
+    it("should create application run successfully with items", async () => {
       const runResponse = {
-        application_run_id: 'run-456',
+        application_run_id: "run-456",
       };
       const items = [
         {
-          reference: 'slide_1',
+          reference: "slide_1",
           input_artifacts: [
             {
-              name: 'input_slide',
-              download_url: 'https://example.com/slide1.tiff',
-              metadata: { mime_type: 'image/tiff' },
+              name: "input_slide",
+              download_url: "https://example.com/slide1.tiff",
+              metadata: { mime_type: "image/tiff" },
             },
           ],
         },
       ];
       platformSDKMock.createApplicationRun.mockResolvedValue(runResponse);
 
-      await createApplicationRun(
-        'production',
+      const result = await createApplicationRun(
+        "production",
         mockAuthService,
-        'test-app',
-        'v1.0.0',
-        JSON.stringify(items)
+        "test-app",
+        "v1.0.0",
+        JSON.stringify(items),
       );
 
       expect(platformSDKMock.createApplicationRun).toHaveBeenCalledWith({
-        application_id: 'test-app',
-        version_number: 'v1.0.0',
+        application_id: "test-app",
+        version_number: "v1.0.0",
         items: items,
       });
-      expect(consoleSpy.log).toHaveBeenCalledWith(
-        '✅ Application run created successfully:',
-        JSON.stringify(runResponse, null, 2)
-      );
+      expect(result).toEqual(runResponse);
     });
 
-    it('should handle invalid JSON in items parameter', async () => {
+    it("should handle invalid JSON in items parameter", async () => {
       await createApplicationRun(
-        'production',
+        "production",
         mockAuthService,
-        'test-app',
-        'v1.0.0',
-        'invalid-json'
+        "test-app",
+        "v1.0.0",
+        "invalid-json",
       );
 
-      expect(consoleSpy.error).toHaveBeenCalledWith('❌ Invalid items JSON:', expect.any(Error));
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        "❌ Invalid items JSON:",
+        expect.any(Error),
+      );
       expect(mockExit).toHaveBeenCalledWith(1);
       expect(platformSDKMock.createApplicationRun).not.toHaveBeenCalled();
     });
 
-    it('should handle non-array items parameter', async () => {
+    it("should handle non-array items parameter", async () => {
       await createApplicationRun(
-        'production',
+        "production",
         mockAuthService,
-        'test-app',
-        'v1.0.0',
-        '{"not": "an array"}'
+        "test-app",
+        "v1.0.0",
+        '{"not": "an array"}',
       );
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Invalid items JSON:',
+        "❌ Invalid items JSON:",
         expect.objectContaining({
-          message: 'Items must be an array',
-        })
+          message: "Items must be an array",
+        }),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
       expect(platformSDKMock.createApplicationRun).not.toHaveBeenCalled();
     });
 
-    it('should handle API error during run creation', async () => {
-      platformSDKMock.createApplicationRun.mockRejectedValue(new Error('API error'));
+    it("should handle API error during run creation", async () => {
+      platformSDKMock.createApplicationRun.mockRejectedValue(
+        new Error("API error"),
+      );
 
-      await createApplicationRun('production', mockAuthService, 'test-app', 'v1.0.0', '[]');
+      await createApplicationRun(
+        "production",
+        mockAuthService,
+        "test-app",
+        "v1.0.0",
+        "[]",
+      );
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Failed to create application run:',
-        expect.any(Error)
+        "❌ Failed to create application run:",
+        expect.any(Error),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
   });
 
-  describe('handleLogin', () => {
-    const mockAuthCode = 'test-auth-code';
-    const mockCodeVerifier = 'test-code-verifier';
-    const mockCodeVerifierHex = Buffer.from(mockCodeVerifier, 'utf-8').toString('hex');
+  describe("handleLogin", () => {
+    const mockAuthCode = "test-auth-code";
+    const mockCodeVerifier = "test-code-verifier";
+    const mockCodeVerifierHex = Buffer.from(mockCodeVerifier, "utf-8").toString(
+      "hex",
+    );
     // Mock console methods
     const mockConsole = {
       log: vi.fn(),
@@ -1266,101 +1368,117 @@ describe('CLI Functions Unit Tests', () => {
     };
 
     beforeEach(() => {
-      vi.spyOn(console, 'log').mockImplementation(mockConsole.log);
-      vi.spyOn(console, 'error').mockImplementation(mockConsole.error);
-      (crypto.randomBytes as Mock).mockReturnValue(Buffer.from(mockCodeVerifier, 'utf-8'));
+      vi.spyOn(console, "log").mockImplementation(mockConsole.log);
+      vi.spyOn(console, "error").mockImplementation(mockConsole.error);
+      (crypto.randomBytes as Mock).mockReturnValue(
+        Buffer.from(mockCodeVerifier, "utf-8"),
+      );
       (startCallbackServer as Mock).mockResolvedValue(mockServer);
     });
 
-    it('should complete login flow successfully', async () => {
+    it("should complete login flow successfully", async () => {
       (waitForCallback as Mock).mockResolvedValue(mockAuthCode);
-      vi.mocked(mockAuthService.loginWithCallback).mockResolvedValue('');
+      vi.mocked(mockAuthService.loginWithCallback).mockResolvedValue("");
       vi.mocked(mockAuthService.completeLogin).mockResolvedValue(undefined);
 
-      await handleLogin('production', mockAuthService);
+      await handleLogin("production", mockAuthService);
 
       // Verify the flow
       expect(crypto.randomBytes).toHaveBeenCalledWith(32);
       expect(startCallbackServer).toHaveBeenCalled();
-      expect(mockAuthService.loginWithCallback).toHaveBeenCalledWith('production', {
-        redirectUri: 'http://localhost:8989',
-        codeVerifier: mockCodeVerifierHex,
-      });
-      expect(waitForCallback).toHaveBeenCalledWith(mockServer);
-      expect(mockAuthService.completeLogin).toHaveBeenCalledWith(
-        'production',
+      expect(mockAuthService.loginWithCallback).toHaveBeenCalledWith(
+        "production",
         {
-          redirectUri: 'http://localhost:8989',
+          redirectUri: "http://localhost:8989",
           codeVerifier: mockCodeVerifierHex,
         },
-        mockAuthCode
+      );
+      expect(waitForCallback).toHaveBeenCalledWith(mockServer);
+      expect(mockAuthService.completeLogin).toHaveBeenCalledWith(
+        "production",
+        {
+          redirectUri: "http://localhost:8989",
+          codeVerifier: mockCodeVerifierHex,
+        },
+        mockAuthCode,
       );
       expect(mockServer.close).toHaveBeenCalled();
     });
 
-    it('should handle server address as number', async () => {
+    it("should handle server address as number", async () => {
       const mockServer = {
         address: vi.fn().mockReturnValue(8990),
         close: vi.fn(),
       };
 
       (startCallbackServer as Mock).mockResolvedValue(mockServer);
-      (waitForCallback as Mock).mockResolvedValue('auth-code');
-      vi.mocked(mockAuthService.loginWithCallback).mockResolvedValue('');
+      (waitForCallback as Mock).mockResolvedValue("auth-code");
+      vi.mocked(mockAuthService.loginWithCallback).mockResolvedValue("");
       vi.mocked(mockAuthService.completeLogin).mockResolvedValue(undefined);
 
-      await handleLogin('production', mockAuthService);
+      await handleLogin("production", mockAuthService);
 
       expect(mockAuthService.loginWithCallback).toHaveBeenCalledWith(
-        'production',
+        "production",
         expect.objectContaining({
-          redirectUri: 'http://localhost:8989', // Should fallback to 8989
-        })
+          redirectUri: "http://localhost:8989", // Should fallback to 8989
+        }),
       );
     });
 
-    it('should handle authentication errors and close server', async () => {
-      const mockError = new Error('Authentication failed');
+    it("should handle authentication errors and close server", async () => {
+      const mockError = new Error("Authentication failed");
 
       vi.mocked(mockAuthService.loginWithCallback).mockRejectedValue(mockError);
 
-      await expect(handleLogin('production', mockAuthService)).rejects.toThrow(
-        'Authentication failed'
+      await expect(handleLogin("production", mockAuthService)).rejects.toThrow(
+        "Authentication failed",
       );
 
-      expect(mockConsole.error).toHaveBeenCalledWith('❌ Authentication failed:', mockError);
+      expect(mockConsole.error).toHaveBeenCalledWith(
+        "❌ Authentication failed:",
+        mockError,
+      );
       expect(mockServer.close).toHaveBeenCalled();
     });
 
-    it('should handle callback wait errors and close server', async () => {
-      const mockError = new Error('Callback timeout');
+    it("should handle callback wait errors and close server", async () => {
+      const mockError = new Error("Callback timeout");
 
-      vi.mocked(mockAuthService.loginWithCallback).mockResolvedValue('');
+      vi.mocked(mockAuthService.loginWithCallback).mockResolvedValue("");
       (waitForCallback as Mock).mockRejectedValue(mockError);
 
-      await expect(handleLogin('production', mockAuthService)).rejects.toThrow('Callback timeout');
+      await expect(handleLogin("production", mockAuthService)).rejects.toThrow(
+        "Callback timeout",
+      );
 
-      expect(mockConsole.error).toHaveBeenCalledWith('❌ Authentication failed:', mockError);
+      expect(mockConsole.error).toHaveBeenCalledWith(
+        "❌ Authentication failed:",
+        mockError,
+      );
       expect(mockServer.close).toHaveBeenCalled();
     });
 
-    it('should handle token exchange errors and close server', async () => {
-      const mockError = new Error('Token exchange failed');
+    it("should handle token exchange errors and close server", async () => {
+      const mockError = new Error("Token exchange failed");
 
-      (waitForCallback as Mock).mockResolvedValue('auth-code');
-      vi.mocked(mockAuthService.loginWithCallback).mockResolvedValue('');
+      (waitForCallback as Mock).mockResolvedValue("auth-code");
+      vi.mocked(mockAuthService.loginWithCallback).mockResolvedValue("");
       vi.mocked(mockAuthService.completeLogin).mockRejectedValue(mockError);
 
-      await expect(handleLogin('production', mockAuthService)).rejects.toThrow(
-        'Token exchange failed'
+      await expect(handleLogin("production", mockAuthService)).rejects.toThrow(
+        "Token exchange failed",
       );
 
-      expect(mockConsole.error).toHaveBeenCalledWith('❌ Authentication failed:', mockError);
+      expect(mockConsole.error).toHaveBeenCalledWith(
+        "❌ Authentication failed:",
+        mockError,
+      );
       expect(mockServer.close).toHaveBeenCalled();
     });
   });
 
-  describe('handleLogout', () => {
+  describe("handleLogout", () => {
     // Mock console methods
     const mockConsole = {
       log: vi.fn(),
@@ -1368,27 +1486,29 @@ describe('CLI Functions Unit Tests', () => {
     };
 
     beforeEach(() => {
-      vi.spyOn(console, 'log').mockImplementation(mockConsole.log);
-      vi.spyOn(console, 'error').mockImplementation(mockConsole.error);
+      vi.spyOn(console, "log").mockImplementation(mockConsole.log);
+      vi.spyOn(console, "error").mockImplementation(mockConsole.error);
     });
 
-    it('should call logout function', async () => {
+    it("should call logout function", async () => {
       vi.mocked(mockAuthService.logout).mockResolvedValue(undefined);
 
-      await handleLogout('production', mockAuthService);
+      await handleLogout("production", mockAuthService);
 
       expect(mockAuthService.logout).toHaveBeenCalled();
     });
 
-    it('should handle logout errors', async () => {
-      const mockError = new Error('Logout failed');
+    it("should handle logout errors", async () => {
+      const mockError = new Error("Logout failed");
       vi.mocked(mockAuthService.logout).mockRejectedValue(mockError);
 
-      await expect(handleLogout('production', mockAuthService)).rejects.toThrow('Logout failed');
+      await expect(handleLogout("production", mockAuthService)).rejects.toThrow(
+        "Logout failed",
+      );
     });
   });
 
-  describe('handleStatus', () => {
+  describe("handleStatus", () => {
     // Mock console methods
     const mockConsole = {
       log: vi.fn(),
@@ -1396,24 +1516,24 @@ describe('CLI Functions Unit Tests', () => {
     };
 
     beforeEach(() => {
-      vi.spyOn(console, 'log').mockImplementation(mockConsole.log);
-      vi.spyOn(console, 'error').mockImplementation(mockConsole.error);
+      vi.spyOn(console, "log").mockImplementation(mockConsole.log);
+      vi.spyOn(console, "error").mockImplementation(mockConsole.error);
 
       // Mock process.exit
-      vi.spyOn(process, 'exit').mockImplementation(() => {
-        throw new Error('process.exit called');
+      vi.spyOn(process, "exit").mockImplementation(() => {
+        throw new Error("process.exit called");
       });
     });
 
-    it('should display authenticated status with expiring token', async () => {
-      const mockExpiresAt = new Date('2025-01-01T12:59:59.000Z');
-      const mockStoredAt = new Date('2024-12-01T10:00:00.000Z');
+    it("should display authenticated status with expiring token", async () => {
+      const mockExpiresAt = new Date("2025-01-01T12:59:59.000Z");
+      const mockStoredAt = new Date("2024-12-01T10:00:00.000Z");
 
       const mockAuthState: AuthState = {
         isAuthenticated: true,
         token: {
-          type: 'Bearer',
-          scope: 'openid profile email offline_access',
+          type: "Bearer",
+          scope: "openid profile email offline_access",
           expiresAt: mockExpiresAt,
           storedAt: mockStoredAt,
         },
@@ -1421,28 +1541,30 @@ describe('CLI Functions Unit Tests', () => {
 
       vi.mocked(mockAuthService.getAuthState).mockResolvedValue(mockAuthState);
 
-      await handleStatus('production', mockAuthService);
+      await handleStatus("production", mockAuthService);
 
-      expect(mockConsole.log).toHaveBeenCalledWith('✅ Authenticated');
-      expect(mockConsole.log).toHaveBeenCalledWith('Token details:');
-      expect(mockConsole.log).toHaveBeenCalledWith('  - Type: Bearer');
+      expect(mockConsole.log).toHaveBeenCalledWith("✅ Authenticated");
+      expect(mockConsole.log).toHaveBeenCalledWith("Token details:");
+      expect(mockConsole.log).toHaveBeenCalledWith("  - Type: Bearer");
       expect(mockConsole.log).toHaveBeenCalledWith(
-        '  - Scope: openid profile email offline_access'
+        "  - Scope: openid profile email offline_access",
       );
       expect(mockConsole.log).toHaveBeenCalledWith(
-        `  - Expires: ${mockExpiresAt.toLocaleString()}`
+        `  - Expires: ${mockExpiresAt.toLocaleString()}`,
       );
-      expect(mockConsole.log).toHaveBeenCalledWith(`  - Stored: ${mockStoredAt.toLocaleString()}`);
+      expect(mockConsole.log).toHaveBeenCalledWith(
+        `  - Stored: ${mockStoredAt.toLocaleString()}`,
+      );
     });
 
-    it('should display authenticated status with non-expiring token', async () => {
-      const mockStoredAt = new Date('2024-12-01T10:00:00.000Z');
+    it("should display authenticated status with non-expiring token", async () => {
+      const mockStoredAt = new Date("2024-12-01T10:00:00.000Z");
 
       const mockAuthState: AuthState = {
         isAuthenticated: true,
         token: {
-          type: 'Bearer',
-          scope: 'openid profile email offline_access',
+          type: "Bearer",
+          scope: "openid profile email offline_access",
           expiresAt: undefined,
           storedAt: mockStoredAt,
         },
@@ -1450,93 +1572,120 @@ describe('CLI Functions Unit Tests', () => {
 
       vi.mocked(mockAuthService.getAuthState).mockResolvedValue(mockAuthState);
 
-      await handleStatus('production', mockAuthService);
+      await handleStatus("production", mockAuthService);
 
-      expect(mockConsole.log).toHaveBeenCalledWith('✅ Authenticated');
-      expect(mockConsole.log).toHaveBeenCalledWith('Token details:');
-      expect(mockConsole.log).toHaveBeenCalledWith('  - Type: Bearer');
+      expect(mockConsole.log).toHaveBeenCalledWith("✅ Authenticated");
+      expect(mockConsole.log).toHaveBeenCalledWith("Token details:");
+      expect(mockConsole.log).toHaveBeenCalledWith("  - Type: Bearer");
       expect(mockConsole.log).toHaveBeenCalledWith(
-        '  - Scope: openid profile email offline_access'
+        "  - Scope: openid profile email offline_access",
       );
-      expect(mockConsole.log).toHaveBeenCalledWith('  - Expires: Never');
-      expect(mockConsole.log).toHaveBeenCalledWith(`  - Stored: ${mockStoredAt.toLocaleString()}`);
+      expect(mockConsole.log).toHaveBeenCalledWith("  - Expires: Never");
+      expect(mockConsole.log).toHaveBeenCalledWith(
+        `  - Stored: ${mockStoredAt.toLocaleString()}`,
+      );
     });
 
-    it('should display not authenticated status', async () => {
+    it("should display not authenticated status", async () => {
       const mockAuthState: AuthState = {
         isAuthenticated: false,
       };
 
       vi.mocked(mockAuthService.getAuthState).mockResolvedValue(mockAuthState);
 
-      await handleStatus('production', mockAuthService);
+      await handleStatus("production", mockAuthService);
 
       expect(mockConsole.log).toHaveBeenCalledWith(
-        '❌ Not authenticated. Run "aignostics-platform login" to authenticate.'
+        '❌ Not authenticated. Run "aignostics-platform login" to authenticate.',
       );
     });
 
-    it('should handle auth state check errors', async () => {
-      const mockError = new Error('Failed to check auth state');
+    it("should handle auth state check errors", async () => {
+      const mockError = new Error("Failed to check auth state");
       vi.mocked(mockAuthService.getAuthState).mockRejectedValue(mockError);
 
-      await expect(handleStatus('production', mockAuthService)).rejects.toThrow(
-        'process.exit called'
+      await expect(handleStatus("production", mockAuthService)).rejects.toThrow(
+        "process.exit called",
       );
 
-      expect(mockConsole.error).toHaveBeenCalledWith('❌ Error checking status:', mockError);
+      expect(mockConsole.error).toHaveBeenCalledWith(
+        "❌ Error checking status:",
+        mockError,
+      );
     });
   });
 
-  describe('handleLoginWithRefreshToken', () => {
+  describe("handleLoginWithRefreshToken", () => {
     let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 
     beforeEach(() => {
-      consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     });
 
-    it('should successfully login with refresh token', async () => {
-      const environment: EnvironmentKey = 'production';
-      const refreshToken = 'test-refresh-token';
+    it("should successfully login with refresh token", async () => {
+      const environment: EnvironmentKey = "production";
+      const refreshToken = "test-refresh-token";
 
-      vi.spyOn(mockAuthService, 'loginWithRefreshToken').mockResolvedValue(undefined);
+      vi.spyOn(mockAuthService, "loginWithRefreshToken").mockResolvedValue(
+        undefined,
+      );
 
-      await handleLoginWithRefreshToken(environment, refreshToken, mockAuthService);
+      await handleLoginWithRefreshToken(
+        environment,
+        refreshToken,
+        mockAuthService,
+      );
 
-      expect(mockAuthService.loginWithRefreshToken).toHaveBeenCalledWith(environment, refreshToken);
+      expect(mockAuthService.loginWithRefreshToken).toHaveBeenCalledWith(
+        environment,
+        refreshToken,
+      );
       expect(consoleErrorSpy).not.toHaveBeenCalled();
     });
 
-    it('should handle login failure and exit process', async () => {
-      const environment: EnvironmentKey = 'production';
-      const refreshToken = 'invalid-refresh-token';
-      const error = new Error('Invalid refresh token');
+    it("should handle login failure and exit process", async () => {
+      const environment: EnvironmentKey = "production";
+      const refreshToken = "invalid-refresh-token";
+      const error = new Error("Invalid refresh token");
 
-      vi.spyOn(mockAuthService, 'loginWithRefreshToken').mockRejectedValue(error);
+      vi.spyOn(mockAuthService, "loginWithRefreshToken").mockRejectedValue(
+        error,
+      );
 
       await expect(
-        handleLoginWithRefreshToken(environment, refreshToken, mockAuthService)
-      ).rejects.toThrow('process.exit called');
+        handleLoginWithRefreshToken(environment, refreshToken, mockAuthService),
+      ).rejects.toThrow("process.exit called");
 
-      expect(mockAuthService.loginWithRefreshToken).toHaveBeenCalledWith(environment, refreshToken);
-      expect(consoleErrorSpy).toHaveBeenCalledWith('❌ Login with refresh token failed:', error);
+      expect(mockAuthService.loginWithRefreshToken).toHaveBeenCalledWith(
+        environment,
+        refreshToken,
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "❌ Login with refresh token failed:",
+        error,
+      );
     });
 
-    it('should handle network errors during login', async () => {
-      const environment: EnvironmentKey = 'staging';
-      const refreshToken = 'test-refresh-token';
-      const networkError = new Error('Network request failed');
+    it("should handle network errors during login", async () => {
+      const environment: EnvironmentKey = "staging";
+      const refreshToken = "test-refresh-token";
+      const networkError = new Error("Network request failed");
 
-      vi.spyOn(mockAuthService, 'loginWithRefreshToken').mockRejectedValue(networkError);
+      vi.spyOn(mockAuthService, "loginWithRefreshToken").mockRejectedValue(
+        networkError,
+      );
 
       await expect(
-        handleLoginWithRefreshToken(environment, refreshToken, mockAuthService)
-      ).rejects.toThrow('process.exit called');
+        handleLoginWithRefreshToken(environment, refreshToken, mockAuthService),
+      ).rejects.toThrow("process.exit called");
 
-      expect(mockAuthService.loginWithRefreshToken).toHaveBeenCalledWith(environment, refreshToken);
+      expect(mockAuthService.loginWithRefreshToken).toHaveBeenCalledWith(
+        environment,
+        refreshToken,
+      );
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        '❌ Login with refresh token failed:',
-        networkError
+        "❌ Login with refresh token failed:",
+        networkError,
       );
     });
   });

--- a/packages/cli/src/cli-functions.ts
+++ b/packages/cli/src/cli-functions.ts
@@ -4,6 +4,16 @@ import {
   type GrantRelation,
   type ResourceType,
   type SubjectType,
+  type GrantReadResponse,
+  type ShareTokenReadResponse,
+  type ShareTokenCreateResponse,
+  type ApplicationReadShortResponse,
+  type ApplicationReadResponse,
+  type ApplicationVersion,
+  type RunReadResponse,
+  type ItemResultReadResponse,
+  type VersionReadResponse,
+  type RunCreationResponse,
 } from '@aignostics/sdk';
 import { AuthService, type LoginWithCallbackConfig } from './utils/auth.js';
 import { startCallbackServer, waitForCallback } from './utils/oauth-callback-server.js';
@@ -14,7 +24,9 @@ import { environmentConfig, EnvironmentKey } from './utils/environment.js';
 
 // Read package.json synchronously for CommonJS compatibility
 const packageJsonPath = join(__dirname, '../package.json');
-const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as { version: string };
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as {
+  version: string;
+};
 
 export function handleInfo(): void {
   console.log('Aignostics Platform SDK');
@@ -46,14 +58,13 @@ export async function testApi(
 export async function listApplications(
   environment: EnvironmentKey,
   authService: AuthService
-): Promise<void> {
+): Promise<ApplicationReadShortResponse[]> {
   const { endpoint } = environmentConfig[environment];
   const sdk = new PlatformSDKHttp({
     baseURL: endpoint,
     tokenProvider: () => authService.getValidAccessToken(environment),
   });
-  const response = await sdk.listApplications();
-  console.log('Applications:', JSON.stringify(response, null, 2));
+  return sdk.listApplications();
 }
 
 export async function getApplicationVersionDetails(
@@ -61,18 +72,14 @@ export async function getApplicationVersionDetails(
   authService: AuthService,
   applicationId: string,
   versionNumber: string
-): Promise<void> {
+): Promise<VersionReadResponse | undefined> {
   const { endpoint } = environmentConfig[environment];
   const sdk = new PlatformSDKHttp({
     baseURL: endpoint,
     tokenProvider: () => authService.getValidAccessToken(environment),
   });
   try {
-    const response = await sdk.getApplicationVersionDetails(applicationId, versionNumber);
-    console.log(
-      `Application version details for ${applicationId} v${versionNumber}:`,
-      JSON.stringify(response, null, 2)
-    );
+    return await sdk.getApplicationVersionDetails(applicationId, versionNumber);
   } catch (error) {
     console.error('❌ Failed to get application version details:', error);
     process.exit(1);
@@ -83,15 +90,14 @@ export async function getApplicationDetails(
   environment: EnvironmentKey,
   authService: AuthService,
   applicationId: string
-): Promise<void> {
+): Promise<ApplicationReadResponse | undefined> {
   const { endpoint } = environmentConfig[environment];
   const sdk = new PlatformSDKHttp({
     baseURL: endpoint,
     tokenProvider: () => authService.getValidAccessToken(environment),
   });
   try {
-    const response = await sdk.getApplication(applicationId);
-    console.log(`Application details for ${applicationId}:`, JSON.stringify(response, null, 2));
+    return await sdk.getApplication(applicationId);
   } catch (error) {
     console.error('❌ Failed to get application details:', error);
     process.exit(1);
@@ -102,7 +108,7 @@ export async function listApplicationVersions(
   environment: EnvironmentKey,
   authService: AuthService,
   applicationId: string
-): Promise<void> {
+): Promise<ApplicationVersion[] | undefined> {
   const { endpoint } = environmentConfig[environment];
   const sdk = new PlatformSDKHttp({
     baseURL: endpoint,
@@ -110,10 +116,7 @@ export async function listApplicationVersions(
   });
   try {
     const response = await sdk.getApplication(applicationId);
-    console.log(
-      `Application versions for ${applicationId}:`,
-      JSON.stringify(response.versions, null, 2)
-    );
+    return response.versions;
   } catch (error) {
     console.error('❌ Failed to list application versions:', error);
     process.exit(1);
@@ -129,7 +132,7 @@ export async function listApplicationRuns(
     customMetadata?: string;
     sort?: string;
   }
-): Promise<void> {
+): Promise<RunReadResponse[] | undefined> {
   let sortBy: string[] | undefined;
 
   if (options?.sort) {
@@ -149,8 +152,7 @@ export async function listApplicationRuns(
     tokenProvider: () => authService.getValidAccessToken(environment),
   });
   try {
-    const response = await sdk.listApplicationRuns({ ...options, sort: sortBy });
-    console.log('Application runs:', JSON.stringify(response, null, 2));
+    return await sdk.listApplicationRuns({ ...options, sort: sortBy });
   } catch (error) {
     console.error('❌ Failed to list application runs:', error);
     process.exit(1);
@@ -161,15 +163,14 @@ export async function getRun(
   environment: EnvironmentKey,
   authService: AuthService,
   applicationRunId: string
-): Promise<void> {
+): Promise<RunReadResponse | undefined> {
   const { endpoint } = environmentConfig[environment];
   const sdk = new PlatformSDKHttp({
     baseURL: endpoint,
     tokenProvider: () => authService.getValidAccessToken(environment),
   });
   try {
-    const response = await sdk.getRun(applicationRunId);
-    console.log(`Run details for ${applicationRunId}:`, JSON.stringify(response, null, 2));
+    return await sdk.getRun(applicationRunId);
   } catch (error) {
     console.error('❌ Failed to get run:', error);
     process.exit(1);
@@ -199,15 +200,14 @@ export async function listRunResults(
   environment: EnvironmentKey,
   authService: AuthService,
   applicationRunId: string
-): Promise<void> {
+): Promise<ItemResultReadResponse[] | undefined> {
   const { endpoint } = environmentConfig[environment];
   const sdk = new PlatformSDKHttp({
     baseURL: endpoint,
     tokenProvider: () => authService.getValidAccessToken(environment),
   });
   try {
-    const response = await sdk.listRunResults(applicationRunId);
-    console.log(`Run results for ${applicationRunId}:`, JSON.stringify(response, null, 2));
+    return await sdk.listRunResults(applicationRunId);
   } catch (error) {
     console.error('❌ Failed to list run results:', error);
     process.exit(1);
@@ -377,7 +377,7 @@ export async function createApplicationRun(
   applicationId: string,
   versionNumber: string,
   itemsJson: string
-): Promise<void> {
+): Promise<RunCreationResponse | undefined> {
   const { endpoint } = environmentConfig[environment];
   const sdk = new PlatformSDKHttp({
     baseURL: endpoint,
@@ -403,7 +403,7 @@ export async function createApplicationRun(
       version_number: versionNumber,
       items: items,
     });
-    console.log('✅ Application run created successfully:', JSON.stringify(response, null, 2));
+    return response;
   } catch (error) {
     console.error('❌ Failed to create application run:', error);
     process.exit(1);
@@ -516,14 +516,14 @@ export async function createGrant(
     subjectEmail?: string;
     relation: GrantRelation;
   }
-): Promise<void> {
+): Promise<GrantReadResponse | undefined> {
   const { endpoint } = environmentConfig[environment];
   const sdk = new PlatformSDKHttp({
     baseURL: endpoint,
     tokenProvider: () => authService.getValidAccessToken(environment),
   });
   try {
-    const response = await sdk.createGrant({
+    return await sdk.createGrant({
       resource_type: options.resourceType,
       resource_id: options.resourceId,
       subject_type: options.subjectType,
@@ -531,7 +531,6 @@ export async function createGrant(
       subject_email: options.subjectEmail,
       relation: options.relation,
     });
-    console.log('✅ Grant created successfully:', JSON.stringify(response, null, 2));
   } catch (error) {
     console.error('❌ Failed to create grant:', error);
     process.exit(1);
@@ -549,14 +548,14 @@ export async function listGrants(
     revoked?: boolean;
     sort?: string;
   }
-): Promise<void> {
+): Promise<GrantReadResponse[] | undefined> {
   const { endpoint } = environmentConfig[environment];
   const sdk = new PlatformSDKHttp({
     baseURL: endpoint,
     tokenProvider: () => authService.getValidAccessToken(environment),
   });
   try {
-    const response = await sdk.listGrants({
+    return await sdk.listGrants({
       resourceType: options?.resourceType,
       resourceId: options?.resourceId,
       subjectType: options?.subjectType,
@@ -564,7 +563,6 @@ export async function listGrants(
       revoked: options?.revoked,
       sort: options?.sort ? [options.sort] : undefined,
     });
-    console.log('Grants:', JSON.stringify(response, null, 2));
   } catch (error) {
     console.error('❌ Failed to list grants:', error);
     process.exit(1);
@@ -575,15 +573,14 @@ export async function getGrant(
   environment: EnvironmentKey,
   authService: AuthService,
   grantId: string
-): Promise<void> {
+): Promise<GrantReadResponse | undefined> {
   const { endpoint } = environmentConfig[environment];
   const sdk = new PlatformSDKHttp({
     baseURL: endpoint,
     tokenProvider: () => authService.getValidAccessToken(environment),
   });
   try {
-    const response = await sdk.getGrant(grantId);
-    console.log(`Grant details for ${grantId}:`, JSON.stringify(response, null, 2));
+    return await sdk.getGrant(grantId);
   } catch (error) {
     console.error('❌ Failed to get grant:', error);
     process.exit(1);
@@ -594,15 +591,14 @@ export async function revokeGrant(
   environment: EnvironmentKey,
   authService: AuthService,
   grantId: string
-): Promise<void> {
+): Promise<GrantReadResponse | undefined> {
   const { endpoint } = environmentConfig[environment];
   const sdk = new PlatformSDKHttp({
     baseURL: endpoint,
     tokenProvider: () => authService.getValidAccessToken(environment),
   });
   try {
-    const response = await sdk.revokeGrant(grantId);
-    console.log(`✅ Grant revoked successfully:`, JSON.stringify(response, null, 2));
+    return await sdk.revokeGrant(grantId);
   } catch (error) {
     console.error('❌ Failed to revoke grant:', error);
     process.exit(1);
@@ -615,7 +611,7 @@ export async function createShareToken(
   options?: {
     expiresAt?: string;
   }
-): Promise<void> {
+): Promise<ShareTokenCreateResponse | undefined> {
   const { endpoint } = environmentConfig[environment];
   const sdk = new PlatformSDKHttp({
     baseURL: endpoint,
@@ -625,8 +621,8 @@ export async function createShareToken(
     const response = await sdk.createShareToken({
       expires_at: options?.expiresAt,
     });
-    console.log('✅ Share token created successfully:', JSON.stringify(response, null, 2));
-    console.log('⚠️  Save the share_token value now — it will not be shown again.');
+    console.error('⚠️  Save the share_token value now — it will not be shown again.');
+    return response;
   } catch (error) {
     console.error('❌ Failed to create share token:', error);
     process.exit(1);
@@ -642,20 +638,19 @@ export async function listShareTokens(
     revoked?: boolean;
     sort?: string;
   }
-): Promise<void> {
+): Promise<ShareTokenReadResponse[] | undefined> {
   const { endpoint } = environmentConfig[environment];
   const sdk = new PlatformSDKHttp({
     baseURL: endpoint,
     tokenProvider: () => authService.getValidAccessToken(environment),
   });
   try {
-    const response = await sdk.listShareTokens({
+    return await sdk.listShareTokens({
       runId: options?.runId,
       createdBy: options?.createdBy,
       revoked: options?.revoked,
       sort: options?.sort ? [options.sort] : undefined,
     });
-    console.log('Share tokens:', JSON.stringify(response, null, 2));
   } catch (error) {
     console.error('❌ Failed to list share tokens:', error);
     process.exit(1);
@@ -666,15 +661,14 @@ export async function getShareToken(
   environment: EnvironmentKey,
   authService: AuthService,
   shareTokenId: string
-): Promise<void> {
+): Promise<ShareTokenReadResponse | undefined> {
   const { endpoint } = environmentConfig[environment];
   const sdk = new PlatformSDKHttp({
     baseURL: endpoint,
     tokenProvider: () => authService.getValidAccessToken(environment),
   });
   try {
-    const response = await sdk.getShareToken(shareTokenId);
-    console.log(`Share token details for ${shareTokenId}:`, JSON.stringify(response, null, 2));
+    return await sdk.getShareToken(shareTokenId);
   } catch (error) {
     console.error('❌ Failed to get share token:', error);
     process.exit(1);
@@ -685,15 +679,14 @@ export async function revokeShareToken(
   environment: EnvironmentKey,
   authService: AuthService,
   shareTokenId: string
-): Promise<void> {
+): Promise<ShareTokenReadResponse | undefined> {
   const { endpoint } = environmentConfig[environment];
   const sdk = new PlatformSDKHttp({
     baseURL: endpoint,
     tokenProvider: () => authService.getValidAccessToken(environment),
   });
   try {
-    const response = await sdk.revokeShareToken(shareTokenId);
-    console.log(`✅ Share token revoked successfully:`, JSON.stringify(response, null, 2));
+    return await sdk.revokeShareToken(shareTokenId);
   } catch (error) {
     console.error('❌ Failed to revoke share token:', error);
     process.exit(1);

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1,54 +1,56 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { main } from './cli.js';
-import { factories, handlers, server } from '@aignostics/sdk/test';
-import { http, HttpResponse } from 'msw';
-import { ZodError } from 'zod';
-import { Readable } from 'stream';
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { main } from "./cli.js";
+import { factories, handlers, server } from "@aignostics/sdk/test";
+import { http, HttpResponse } from "msw";
+import { ZodError } from "zod";
+import { Readable } from "stream";
 
 // Mock process.exit to prevent test runner from exiting
 const mockExit = vi.fn();
-vi.stubGlobal('process', {
+vi.stubGlobal("process", {
   ...process,
   exit: mockExit,
 });
 
 // Mock auth service to avoid real authentication
-vi.mock('./utils/auth.js', () => ({
+vi.mock("./utils/auth.js", () => ({
   AuthService: vi.fn().mockImplementation(() => ({
-    getValidAccessToken: vi.fn().mockResolvedValue('mock-token'),
-    loginWithCallback: vi.fn().mockResolvedValue(''),
+    getValidAccessToken: vi.fn().mockResolvedValue("mock-token"),
+    loginWithCallback: vi.fn().mockResolvedValue(""),
     completeLogin: vi.fn().mockResolvedValue(undefined),
     loginWithRefreshToken: vi.fn().mockResolvedValue(undefined),
     logout: vi.fn().mockResolvedValue(undefined),
     getAuthState: vi.fn().mockResolvedValue({
       isAuthenticated: true,
       token: {
-        type: 'Bearer',
-        scope: 'openid profile email offline_access',
-        expiresAt: new Date('2025-01-01T12:59:59.000Z'),
-        storedAt: new Date('2024-12-01T10:00:00.000Z'),
+        type: "Bearer",
+        scope: "openid profile email offline_access",
+        expiresAt: new Date("2025-01-01T12:59:59.000Z"),
+        storedAt: new Date("2024-12-01T10:00:00.000Z"),
       },
     }),
   })),
 }));
 
 // Mock OAuth callback server
-vi.mock('./utils/oauth-callback-server.js', () => ({
+vi.mock("./utils/oauth-callback-server.js", () => ({
   startCallbackServer: vi.fn().mockResolvedValue({
     address: vi.fn().mockReturnValue({ port: 8989 }),
     close: vi.fn(),
   }),
-  waitForCallback: vi.fn().mockResolvedValue('test-auth-code'),
+  waitForCallback: vi.fn().mockResolvedValue("test-auth-code"),
 }));
 
 // Mock crypto for login
-vi.mock('crypto', () => ({
+vi.mock("crypto", () => ({
   default: {
-    randomBytes: vi.fn().mockReturnValue(Buffer.from('test-code-verifier', 'utf-8')),
+    randomBytes: vi
+      .fn()
+      .mockReturnValue(Buffer.from("test-code-verifier", "utf-8")),
   },
 }));
 
-describe('CLI Integration Tests', () => {
+describe("CLI Integration Tests", () => {
   let consoleSpy: {
     log: ReturnType<typeof vi.spyOn>;
     error: ReturnType<typeof vi.spyOn>;
@@ -72,8 +74,8 @@ describe('CLI Integration Tests', () => {
 
     // Mock console methods to avoid noise in tests
     consoleSpy = {
-      log: vi.spyOn(console, 'log').mockImplementation(() => {}),
-      error: vi.spyOn(console, 'error').mockImplementation(() => {}),
+      log: vi.spyOn(console, "log").mockImplementation(() => {}),
+      error: vi.spyOn(console, "error").mockImplementation(() => {}),
     };
   });
 
@@ -86,611 +88,657 @@ describe('CLI Integration Tests', () => {
     process.argv = originalArgv;
   });
 
-  describe('info command', () => {
-    it('should display SDK information', async () => {
+  describe("info command", () => {
+    it("should display SDK information", async () => {
       // Mock process.argv for yargs
-      process.argv = ['node', 'cli.js', 'info'];
+      process.argv = ["node", "cli.js", "info"];
 
       await main();
 
-      expect(consoleSpy.log).toHaveBeenCalledWith('Aignostics Platform SDK');
-      expect(consoleSpy.log).toHaveBeenCalledWith('Version:', '0.0.0-development');
+      expect(consoleSpy.log).toHaveBeenCalledWith("Aignostics Platform SDK");
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        "Version:",
+        "0.0.0-development",
+      );
     });
   });
 
-  describe('test-api command', () => {
-    it('should test API connection successfully', async () => {
-      // Mock process.argv for yargs
-      process.argv = ['node', 'cli.js', 'test-api', '--endpoint', 'https://api.example.com'];
-
-      await main();
-
-      expect(consoleSpy.log).toHaveBeenCalledWith('✅ API connection successful');
-    });
-  });
-
-  describe('applications list command', () => {
-    it('should list applications successfully', async () => {
+  describe("test-api command", () => {
+    it("should test API connection successfully", async () => {
       // Mock process.argv for yargs
       process.argv = [
-        'node',
-        'cli.js',
-        'applications',
-        'list',
-        '--endpoint',
-        'https://api.example.com',
+        "node",
+        "cli.js",
+        "test-api",
+        "--endpoint",
+        "https://api.example.com",
       ];
 
       await main();
 
       expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Applications:',
-        expect.stringContaining('application_id')
+        "✅ API connection successful",
       );
-      expect(consoleSpy.log).toHaveBeenCalledWith('Applications:', expect.stringContaining('name'));
     });
   });
 
-  describe('applications get command', () => {
-    it('should get application details successfully', async () => {
+  describe("applications list command", () => {
+    it("should list applications successfully", async () => {
+      // Mock process.argv for yargs
+      process.argv = [
+        "node",
+        "cli.js",
+        "applications",
+        "list",
+        "--endpoint",
+        "https://api.example.com",
+        "--format",
+        "json",
+      ];
+
+      await main();
+
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        expect.stringContaining("application_id"),
+      );
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        expect.stringContaining("name"),
+      );
+    });
+  });
+
+  describe("applications get command", () => {
+    it("should get application details successfully", async () => {
       const application = factories.application.build();
       server.use(
-        http.get('*/v1/applications/:applicationId', () =>
-          HttpResponse.json(application, { status: 200 })
-        )
+        http.get("*/v1/applications/:applicationId", () =>
+          HttpResponse.json(application, { status: 200 }),
+        ),
       );
       process.argv = [
-        'node',
-        'cli.js',
-        'applications',
-        'get',
+        "node",
+        "cli.js",
+        "applications",
+        "get",
         application.application_id,
-        '--endpoint',
-        'https://api.example.com',
+        "--endpoint",
+        "https://api.example.com",
+        "--format",
+        "json",
       ];
 
       await main();
 
       expect(consoleSpy.log).toHaveBeenCalledWith(
-        `Application details for ${application.application_id}:`,
-        expect.stringContaining(application.application_id)
+        expect.stringContaining(application.application_id),
       );
     });
 
-    it('should print error responses', async () => {
+    it("should print error responses", async () => {
       const application = factories.application.build();
-      server.use(http.get('*/v1/applications/:applicationId', () => HttpResponse.error()));
+      server.use(
+        http.get("*/v1/applications/:applicationId", () =>
+          HttpResponse.error(),
+        ),
+      );
       process.argv = [
-        'node',
-        'cli.js',
-        'applications',
-        'get',
+        "node",
+        "cli.js",
+        "applications",
+        "get",
         application.application_id,
-        '--endpoint',
-        'https://api.example.com',
+        "--endpoint",
+        "https://api.example.com",
       ];
 
       await main();
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        expect.stringContaining('❌ Failed to get application details:'),
-        expect.any(Error)
+        expect.stringContaining("❌ Failed to get application details:"),
+        expect.any(Error),
       );
     });
   });
 
-  describe('applications versions list command', () => {
-    it('should list application versions successfully', async () => {
+  describe("applications versions list command", () => {
+    it("should list application versions successfully", async () => {
       const application = factories.application.build();
       server.use(
-        http.get('*/v1/applications/:applicationId', () =>
-          HttpResponse.json(application, { status: 200 })
-        )
+        http.get("*/v1/applications/:applicationId", () =>
+          HttpResponse.json(application, { status: 200 }),
+        ),
       );
       // Mock process.argv for yargs
       process.argv = [
-        'node',
-        'cli.js',
-        'applications',
-        'versions',
-        'list',
+        "node",
+        "cli.js",
+        "applications",
+        "versions",
+        "list",
         application.application_id,
-        '--endpoint',
-        'https://api.example.com',
+        "--endpoint",
+        "https://api.example.com",
+        "--format",
+        "json",
       ];
 
       await main();
 
       expect(consoleSpy.log).toHaveBeenCalledWith(
-        `Application versions for ${application.application_id}:`,
         expect.toSatisfy(
-          str =>
-            typeof str === 'string' &&
-            application.versions.every(version => str.includes(version.number))
-        )
+          (str) =>
+            typeof str === "string" &&
+            application.versions.every((version) =>
+              str.includes(version.number),
+            ),
+        ),
       );
     });
 
-    it('should print error responses', async () => {
+    it("should print error responses", async () => {
       const application = factories.application.build();
-      server.use(http.get('*/v1/applications/:applicationId', () => HttpResponse.error()));
+      server.use(
+        http.get("*/v1/applications/:applicationId", () =>
+          HttpResponse.error(),
+        ),
+      );
       // Mock process.argv for yargs
       process.argv = [
-        'node',
-        'cli.js',
-        'applications',
-        'versions',
-        'list',
+        "node",
+        "cli.js",
+        "applications",
+        "versions",
+        "list",
         application.application_id,
-        '--endpoint',
-        'https://api.example.com',
+        "--endpoint",
+        "https://api.example.com",
       ];
 
       await main();
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        expect.stringContaining('❌ Failed to list application versions:'),
-        expect.any(Error)
+        expect.stringContaining("❌ Failed to list application versions:"),
+        expect.any(Error),
       );
     });
   });
 
-  describe('applications versions get command', () => {
-    it('should get application version details successfully', async () => {
+  describe("applications versions get command", () => {
+    it("should get application version details successfully", async () => {
       const application = factories.application.build();
       const version = application.versions[0];
 
       server.use(
-        http.get('*/v1/applications/:applicationId/versions/:versionNumber', () =>
-          HttpResponse.json(version, { status: 200 })
-        )
+        http.get(
+          "*/v1/applications/:applicationId/versions/:versionNumber",
+          () => HttpResponse.json(version, { status: 200 }),
+        ),
       );
 
       process.argv = [
-        'node',
-        'cli.js',
-        'applications',
-        'versions',
-        'get',
+        "node",
+        "cli.js",
+        "applications",
+        "versions",
+        "get",
         application.application_id,
         version.number,
-        '--endpoint',
-        'https://api.example.com',
+        "--endpoint",
+        "https://api.example.com",
+        "--format",
+        "json",
       ];
 
       await main();
 
       expect(consoleSpy.log).toHaveBeenCalledWith(
-        `Application version details for ${application.application_id} v${version.number}:`,
-        expect.stringContaining(version.number)
+        expect.stringContaining(version.number),
       );
     });
 
-    it('should print error responses', async () => {
+    it("should print error responses", async () => {
       const application = factories.application.build();
       const version = application.versions[0];
 
       server.use(
-        http.get('*/v1/applications/:applicationId/versions/:versionNumber', () =>
-          HttpResponse.error()
-        )
+        http.get(
+          "*/v1/applications/:applicationId/versions/:versionNumber",
+          () => HttpResponse.error(),
+        ),
       );
 
       process.argv = [
-        'node',
-        'cli.js',
-        'applications',
-        'versions',
-        'get',
+        "node",
+        "cli.js",
+        "applications",
+        "versions",
+        "get",
         application.application_id,
         version.number,
-        '--endpoint',
-        'https://api.example.com',
+        "--endpoint",
+        "https://api.example.com",
       ];
 
       await main();
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        expect.stringContaining('❌ Failed to get application version details:'),
-        expect.any(Error)
+        expect.stringContaining(
+          "❌ Failed to get application version details:",
+        ),
+        expect.any(Error),
       );
     });
 
-    it('should require applicationId and versionNumber parameters', async () => {
-      process.argv = ['node', 'cli.js', 'applications', 'versions', 'get'];
+    it("should require applicationId and versionNumber parameters", async () => {
+      process.argv = ["node", "cli.js", "applications", "versions", "get"];
 
       await main();
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        expect.stringContaining('Not enough non-option arguments')
+        expect.stringContaining("Not enough non-option arguments"),
       );
     });
   });
 
-  describe('runs list command', () => {
-    it('should list application runs successfully', async () => {
-      // Mock process.argv for yargs
-      process.argv = ['node', 'cli.js', 'runs', 'list', '--endpoint', 'https://api.example.com'];
-
-      await main();
-
-      expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Application runs:',
-        expect.stringContaining('run_id')
-      );
-      expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Application runs:',
-        expect.stringContaining('state')
-      );
-    });
-
-    it('should support filtering by applicationId', async () => {
+  describe("runs list command", () => {
+    it("should list application runs successfully", async () => {
       // Mock process.argv for yargs
       process.argv = [
-        'node',
-        'cli.js',
-        'runs',
-        'list',
-        '--applicationId',
-        'app1',
-        '--endpoint',
-        'https://api.example.com',
+        "node",
+        "cli.js",
+        "runs",
+        "list",
+        "--endpoint",
+        "https://api.example.com",
+        "--format",
+        "json",
       ];
 
       await main();
 
       expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Application runs:',
-        expect.stringContaining('run_id')
+        expect.stringContaining("run_id"),
+      );
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        expect.stringContaining("state"),
       );
     });
 
-    it('should support filtering by applicationVersion', async () => {
+    it("should support filtering by applicationId", async () => {
       // Mock process.argv for yargs
       process.argv = [
-        'node',
-        'cli.js',
-        'runs',
-        'list',
-        '--applicationVersion',
-        'v1.0.0',
-        '--endpoint',
-        'https://api.example.com',
+        "node",
+        "cli.js",
+        "runs",
+        "list",
+        "--applicationId",
+        "app1",
+        "--endpoint",
+        "https://api.example.com",
+        "--format",
+        "json",
       ];
 
       await main();
 
       expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Application runs:',
-        expect.stringContaining('run_id')
+        expect.stringContaining("run_id"),
+      );
+    });
+
+    it("should support filtering by applicationVersion", async () => {
+      // Mock process.argv for yargs
+      process.argv = [
+        "node",
+        "cli.js",
+        "runs",
+        "list",
+        "--applicationVersion",
+        "v1.0.0",
+        "--endpoint",
+        "https://api.example.com",
+        "--format",
+        "json",
+      ];
+
+      await main();
+
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        expect.stringContaining("run_id"),
       );
     });
   });
 
-  describe('runs get command', () => {
-    it('should get run details successfully', async () => {
+  describe("runs get command", () => {
+    it("should get run details successfully", async () => {
       // Mock process.argv for yargs
       process.argv = [
-        'node',
-        'cli.js',
-        'runs',
-        'get',
-        'run-1',
-        '--endpoint',
-        'https://api.example.com',
+        "node",
+        "cli.js",
+        "runs",
+        "get",
+        "run-1",
+        "--endpoint",
+        "https://api.example.com",
+        "--format",
+        "json",
       ];
 
       await main();
 
       expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Run details for run-1:',
-        expect.stringContaining('run_id')
+        expect.stringContaining("run_id"),
       );
       expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Run details for run-1:',
-        expect.stringContaining('state')
+        expect.stringContaining("state"),
       );
     });
 
-    it('should require applicationRunId parameter', async () => {
+    it("should require applicationRunId parameter", async () => {
       // Mock process.argv for yargs - missing applicationRunId
-      process.argv = ['node', 'cli.js', 'runs', 'get'];
+      process.argv = ["node", "cli.js", "runs", "get"];
 
       await main();
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        expect.stringContaining('Not enough non-option arguments')
+        expect.stringContaining("Not enough non-option arguments"),
       );
     });
   });
 
-  describe('runs cancel command', () => {
-    it('should cancel run successfully', async () => {
+  describe("runs cancel command", () => {
+    it("should cancel run successfully", async () => {
       // Mock process.argv for yargs
       process.argv = [
-        'node',
-        'cli.js',
-        'runs',
-        'cancel',
-        'run-1',
-        '--endpoint',
-        'https://api.example.com',
+        "node",
+        "cli.js",
+        "runs",
+        "cancel",
+        "run-1",
+        "--endpoint",
+        "https://api.example.com",
       ];
 
       await main();
 
       expect(consoleSpy.log).toHaveBeenCalledWith(
-        '✅ Successfully cancelled application run: run-1'
+        "✅ Successfully cancelled application run: run-1",
       );
     });
 
-    it('should require applicationRunId parameter', async () => {
+    it("should require applicationRunId parameter", async () => {
       // Mock process.argv for yargs - missing applicationRunId
-      process.argv = ['node', 'cli.js', 'runs', 'cancel'];
+      process.argv = ["node", "cli.js", "runs", "cancel"];
 
       await main();
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        expect.stringContaining('Not enough non-option arguments')
+        expect.stringContaining("Not enough non-option arguments"),
       );
     });
   });
 
-  describe('runs results list command', () => {
-    it('should list run results successfully', async () => {
+  describe("runs results list command", () => {
+    it("should list run results successfully", async () => {
       // Mock process.argv for yargs
       process.argv = [
-        'node',
-        'cli.js',
-        'runs',
-        'results',
-        'list',
-        'run-1',
-        '--endpoint',
-        'https://api.example.com',
+        "node",
+        "cli.js",
+        "runs",
+        "results",
+        "list",
+        "run-1",
+        "--endpoint",
+        "https://api.example.com",
+        "--format",
+        "json",
       ];
 
       await main();
 
       expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Run results for run-1:',
-        expect.stringContaining('item_id')
+        expect.stringContaining("item_id"),
       );
       expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Run results for run-1:',
-        expect.stringContaining('status')
+        expect.stringContaining("status"),
       );
     });
 
-    it('should require applicationRunId parameter', async () => {
+    it("should require applicationRunId parameter", async () => {
       // Mock process.argv for yargs - missing applicationRunId
-      process.argv = ['node', 'cli.js', 'runs', 'results', 'list'];
+      process.argv = ["node", "cli.js", "runs", "results", "list"];
 
       await main();
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        expect.stringContaining('Not enough non-option arguments')
+        expect.stringContaining("Not enough non-option arguments"),
       );
     });
   });
 
-  describe('runs results delete command', () => {
-    it('should delete run results successfully', async () => {
+  describe("runs results delete command", () => {
+    it("should delete run results successfully", async () => {
       process.argv = [
-        'node',
-        'cli.js',
-        'runs',
-        'results',
-        'delete',
-        'run-1',
-        '--endpoint',
-        'https://api.example.com',
+        "node",
+        "cli.js",
+        "runs",
+        "results",
+        "delete",
+        "run-1",
+        "--endpoint",
+        "https://api.example.com",
       ];
 
       await main();
 
-      expect(consoleSpy.log).toHaveBeenCalledWith('✅ Successfully deleted results for run: run-1');
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        "✅ Successfully deleted results for run: run-1",
+      );
     });
 
-    it('should require applicationRunId parameter', async () => {
-      process.argv = ['node', 'cli.js', 'runs', 'results', 'delete'];
+    it("should require applicationRunId parameter", async () => {
+      process.argv = ["node", "cli.js", "runs", "results", "delete"];
 
       await main();
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        expect.stringContaining('Not enough non-option arguments')
+        expect.stringContaining("Not enough non-option arguments"),
       );
     });
   });
 
-  describe('runs metadata set command', () => {
-    it('should update run custom metadata successfully', async () => {
+  describe("runs metadata set command", () => {
+    it("should update run custom metadata successfully", async () => {
       process.argv = [
-        'node',
-        'cli.js',
-        'runs',
-        'metadata',
-        'set',
-        'run-1',
+        "node",
+        "cli.js",
+        "runs",
+        "metadata",
+        "set",
+        "run-1",
         '{"note":"reviewed"}',
-        '--endpoint',
-        'https://api.example.com',
+        "--endpoint",
+        "https://api.example.com",
       ];
 
       await main();
 
       expect(consoleSpy.log).toHaveBeenCalledWith(
-        '✅ Updated custom metadata for run run-1:',
-        expect.stringContaining('custom_metadata_checksum')
+        "✅ Updated custom metadata for run run-1:",
+        expect.stringContaining("custom_metadata_checksum"),
       );
     });
 
-    it('should require applicationRunId and customMetadata parameters', async () => {
-      process.argv = ['node', 'cli.js', 'runs', 'metadata', 'set'];
+    it("should require applicationRunId and customMetadata parameters", async () => {
+      process.argv = ["node", "cli.js", "runs", "metadata", "set"];
 
       await main();
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        expect.stringContaining('Not enough non-option arguments')
+        expect.stringContaining("Not enough non-option arguments"),
       );
     });
   });
 
-  describe('runs items get command', () => {
-    it('should get a single run item successfully', async () => {
+  describe("runs items get command", () => {
+    it("should get a single run item successfully", async () => {
       process.argv = [
-        'node',
-        'cli.js',
-        'runs',
-        'items',
-        'get',
-        'run-1',
-        'ext-1',
-        '--endpoint',
-        'https://api.example.com',
+        "node",
+        "cli.js",
+        "runs",
+        "items",
+        "get",
+        "run-1",
+        "ext-1",
+        "--endpoint",
+        "https://api.example.com",
       ];
 
       await main();
 
       expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Run item details for run-1/ext-1:',
-        expect.stringContaining('item_id')
+        "Run item details for run-1/ext-1:",
+        expect.stringContaining("item_id"),
       );
     });
 
-    it('should require applicationRunId and externalId parameters', async () => {
-      process.argv = ['node', 'cli.js', 'runs', 'items', 'get'];
+    it("should require applicationRunId and externalId parameters", async () => {
+      process.argv = ["node", "cli.js", "runs", "items", "get"];
 
       await main();
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        expect.stringContaining('Not enough non-option arguments')
+        expect.stringContaining("Not enough non-option arguments"),
       );
     });
   });
 
-  describe('runs items metadata set command', () => {
-    it('should update run item custom metadata successfully', async () => {
+  describe("runs items metadata set command", () => {
+    it("should update run item custom metadata successfully", async () => {
       process.argv = [
-        'node',
-        'cli.js',
-        'runs',
-        'items',
-        'metadata',
-        'set',
-        'run-1',
-        'ext-1',
+        "node",
+        "cli.js",
+        "runs",
+        "items",
+        "metadata",
+        "set",
+        "run-1",
+        "ext-1",
         '{"reviewed":true}',
-        '--endpoint',
-        'https://api.example.com',
+        "--endpoint",
+        "https://api.example.com",
       ];
 
       await main();
 
       expect(consoleSpy.log).toHaveBeenCalledWith(
-        '✅ Updated custom metadata for item run-1/ext-1:',
-        expect.stringContaining('custom_metadata_checksum')
+        "✅ Updated custom metadata for item run-1/ext-1:",
+        expect.stringContaining("custom_metadata_checksum"),
       );
     });
 
-    it('should require applicationRunId, externalId, and customMetadata parameters', async () => {
-      process.argv = ['node', 'cli.js', 'runs', 'items', 'metadata', 'set'];
+    it("should require applicationRunId, externalId, and customMetadata parameters", async () => {
+      process.argv = ["node", "cli.js", "runs", "items", "metadata", "set"];
 
       await main();
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        expect.stringContaining('Not enough non-option arguments')
+        expect.stringContaining("Not enough non-option arguments"),
       );
     });
   });
 
-  describe('runs create command', () => {
-    it('should create application run successfully with empty items', async () => {
+  describe("runs create command", () => {
+    it("should create application run successfully with empty items", async () => {
       // Mock process.argv for yargs
       process.argv = [
-        'node',
-        'cli.js',
-        'runs',
-        'create',
-        'test-app',
-        'v1.0.0',
-        '--endpoint',
-        'https://api.example.com',
-        '--items',
-        '[]',
+        "node",
+        "cli.js",
+        "runs",
+        "create",
+        "test-app",
+        "v1.0.0",
+        "--endpoint",
+        "https://api.example.com",
+        "--items",
+        "[]",
+        "--format",
+        "json",
       ];
 
       await main();
 
       expect(consoleSpy.log).toHaveBeenCalledWith(
-        '✅ Application run created successfully:',
-        expect.stringContaining('run_id')
+        expect.stringContaining("run_id"),
       );
     });
 
-    it('should create application run successfully with default empty items', async () => {
+    it("should create application run successfully with default empty items", async () => {
       // Mock process.argv for yargs - without explicit --items parameter
       process.argv = [
-        'node',
-        'cli.js',
-        'runs',
-        'create',
-        'test-app',
-        'v1.0.0',
-        '--endpoint',
-        'https://api.example.com',
+        "node",
+        "cli.js",
+        "runs",
+        "create",
+        "test-app",
+        "v1.0.0",
+        "--endpoint",
+        "https://api.example.com",
+        "--format",
+        "json",
       ];
 
       await main();
 
       expect(consoleSpy.log).toHaveBeenCalledWith(
-        '✅ Application run created successfully:',
-        expect.stringContaining('run_id')
+        expect.stringContaining("run_id"),
       );
     });
 
-    it('should require applicationId and versionNumber parameters', async () => {
+    it("should require applicationId and versionNumber parameters", async () => {
       // Mock process.argv for yargs - missing applicationId and versionNumber
-      process.argv = ['node', 'cli.js', 'runs', 'create'];
+      process.argv = ["node", "cli.js", "runs", "create"];
 
       await main();
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        expect.stringContaining('Not enough non-option arguments')
+        expect.stringContaining("Not enough non-option arguments"),
       );
     });
   });
 
-  describe('CLI argument parsing', () => {
-    it('should handle version flag', async () => {
+  describe("CLI argument parsing", () => {
+    it("should handle version flag", async () => {
       // Mock process.argv for yargs
-      process.argv = ['node', 'cli.js', '--version'];
+      process.argv = ["node", "cli.js", "--version"];
 
       // Mock process.exit to prevent actual exit
-      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
-        throw new Error('process.exit called');
+      const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+        throw new Error("process.exit called");
       });
 
       try {
         await main();
       } catch (error) {
-        expect((error as Error).message).toContain('process.exit');
+        expect((error as Error).message).toContain("process.exit");
       }
 
       exitSpy.mockRestore();
     });
 
-    it('should handle help flag', async () => {
+    it("should handle help flag", async () => {
       mockExit.mockImplementation(() => {});
-      vi.stubGlobal('process', { ...process, exit: mockExit });
+      vi.stubGlobal("process", { ...process, exit: mockExit });
       // Mock process.argv for yargs
-      process.argv = ['node', 'cli.js', '--help'];
+      process.argv = ["node", "cli.js", "--help"];
 
       await expect(main()).rejects.toThrow();
 
-      expect(consoleSpy.log).toHaveBeenCalledWith(expect.stringContaining('Usage:'));
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        expect.stringContaining("Usage:"),
+      );
     });
 
-    it('should require a command', async () => {
+    it("should require a command", async () => {
       // Mock process.argv for yargs
-      process.argv = ['node', 'cli.js'];
+      process.argv = ["node", "cli.js"];
 
       await main();
 
@@ -699,24 +747,26 @@ describe('CLI Integration Tests', () => {
 
       // Check that the error was logged with custom message
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        expect.stringContaining('You need at least one command before moving on')
+        expect.stringContaining(
+          "You need at least one command before moving on",
+        ),
       );
     });
   });
 
-  describe('auth login command', () => {
-    it('should login with refresh token when --refreshToken is provided', async () => {
-      const refreshToken = 'test-refresh-token-12345';
+  describe("auth login command", () => {
+    it("should login with refresh token when --refreshToken is provided", async () => {
+      const refreshToken = "test-refresh-token-12345";
 
       process.argv = [
-        'node',
-        'cli.js',
-        'auth',
-        'login',
-        '--refreshToken',
+        "node",
+        "cli.js",
+        "auth",
+        "login",
+        "--refreshToken",
         refreshToken,
-        '--environment',
-        'production',
+        "--environment",
+        "production",
       ];
 
       await main();
@@ -728,34 +778,40 @@ describe('CLI Integration Tests', () => {
     });
   });
 
-  describe('environment validation', () => {
-    it('should accept valid production environment', async () => {
-      process.argv = ['node', 'cli.js', 'info', '--environment', 'production'];
+  describe("environment validation", () => {
+    it("should accept valid production environment", async () => {
+      process.argv = ["node", "cli.js", "info", "--environment", "production"];
 
       await main();
 
-      expect(consoleSpy.log).toHaveBeenCalledWith('Aignostics Platform SDK');
+      expect(consoleSpy.log).toHaveBeenCalledWith("Aignostics Platform SDK");
       expect(consoleSpy.error).not.toHaveBeenCalled();
     });
 
-    it('should accept valid staging environment', async () => {
-      process.argv = ['node', 'cli.js', 'info', '--environment', 'staging'];
+    it("should accept valid staging environment", async () => {
+      process.argv = ["node", "cli.js", "info", "--environment", "staging"];
 
       await main();
 
-      expect(consoleSpy.log).toHaveBeenCalledWith('Aignostics Platform SDK');
+      expect(consoleSpy.log).toHaveBeenCalledWith("Aignostics Platform SDK");
       expect(consoleSpy.error).not.toHaveBeenCalled();
     });
 
-    it('should reject invalid environment', async () => {
-      process.argv = ['node', 'cli.js', 'test-api', '--environment', 'invalid-env'];
+    it("should reject invalid environment", async () => {
+      process.argv = [
+        "node",
+        "cli.js",
+        "test-api",
+        "--environment",
+        "invalid-env",
+      ];
 
       try {
         await main();
       } catch (error) {
         // Error is expected when validation fails
         expect((error as ZodError).message).toMatch(
-          /Invalid option: expected one of "production"|"staging"|"develop"/
+          /Invalid option: expected one of "production"|"staging"|"develop"/,
         );
       }
 
@@ -763,28 +819,35 @@ describe('CLI Integration Tests', () => {
       expect(mockExit).toHaveBeenCalledWith(1);
     });
 
-    it('should use production as default environment', async () => {
-      process.argv = ['node', 'cli.js', 'info'];
+    it("should use production as default environment", async () => {
+      process.argv = ["node", "cli.js", "info"];
 
       await main();
 
-      expect(consoleSpy.log).toHaveBeenCalledWith('Aignostics Platform SDK');
+      expect(consoleSpy.log).toHaveBeenCalledWith("Aignostics Platform SDK");
       expect(consoleSpy.error).not.toHaveBeenCalled();
     });
 
-    it('should accept develop environment', async () => {
-      process.argv = ['node', 'cli.js', 'info', '--environment', 'develop'];
+    it("should accept develop environment", async () => {
+      process.argv = ["node", "cli.js", "info", "--environment", "develop"];
 
       await main();
 
-      expect(consoleSpy.log).toHaveBeenCalledWith('Aignostics Platform SDK');
+      expect(consoleSpy.log).toHaveBeenCalledWith("Aignostics Platform SDK");
       expect(consoleSpy.error).not.toHaveBeenCalled();
     });
   });
 
-  describe('auth logout command', () => {
-    it('should logout successfully', async () => {
-      process.argv = ['node', 'cli.js', 'auth', 'logout', '--environment', 'production'];
+  describe("auth logout command", () => {
+    it("should logout successfully", async () => {
+      process.argv = [
+        "node",
+        "cli.js",
+        "auth",
+        "logout",
+        "--environment",
+        "production",
+      ];
 
       await main();
 
@@ -792,28 +855,15 @@ describe('CLI Integration Tests', () => {
       expect(mockExit).not.toHaveBeenCalled();
     });
 
-    it('should logout from staging environment', async () => {
-      process.argv = ['node', 'cli.js', 'auth', 'logout', '--environment', 'staging'];
-
-      await main();
-
-      expect(consoleSpy.error).not.toHaveBeenCalled();
-      expect(mockExit).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('auth status command', () => {
-    it('should check authentication status successfully', async () => {
-      process.argv = ['node', 'cli.js', 'auth', 'status', '--environment', 'production'];
-
-      await main();
-
-      expect(consoleSpy.error).not.toHaveBeenCalled();
-      expect(mockExit).not.toHaveBeenCalled();
-    });
-
-    it('should check status for staging environment', async () => {
-      process.argv = ['node', 'cli.js', 'auth', 'status', '--environment', 'staging'];
+    it("should logout from staging environment", async () => {
+      process.argv = [
+        "node",
+        "cli.js",
+        "auth",
+        "logout",
+        "--environment",
+        "staging",
+      ];
 
       await main();
 
@@ -822,9 +872,50 @@ describe('CLI Integration Tests', () => {
     });
   });
 
-  describe('auth login command without refresh token', () => {
-    it('should initiate login flow without refresh token', async () => {
-      process.argv = ['node', 'cli.js', 'auth', 'login', '--environment', 'production'];
+  describe("auth status command", () => {
+    it("should check authentication status successfully", async () => {
+      process.argv = [
+        "node",
+        "cli.js",
+        "auth",
+        "status",
+        "--environment",
+        "production",
+      ];
+
+      await main();
+
+      expect(consoleSpy.error).not.toHaveBeenCalled();
+      expect(mockExit).not.toHaveBeenCalled();
+    });
+
+    it("should check status for staging environment", async () => {
+      process.argv = [
+        "node",
+        "cli.js",
+        "auth",
+        "status",
+        "--environment",
+        "staging",
+      ];
+
+      await main();
+
+      expect(consoleSpy.error).not.toHaveBeenCalled();
+      expect(mockExit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("auth login command without refresh token", () => {
+    it("should initiate login flow without refresh token", async () => {
+      process.argv = [
+        "node",
+        "cli.js",
+        "auth",
+        "login",
+        "--environment",
+        "production",
+      ];
 
       await main();
 
@@ -832,8 +923,15 @@ describe('CLI Integration Tests', () => {
       expect(mockExit).not.toHaveBeenCalled();
     });
 
-    it('should login with staging environment', async () => {
-      process.argv = ['node', 'cli.js', 'auth', 'login', '--environment', 'staging'];
+    it("should login with staging environment", async () => {
+      process.argv = [
+        "node",
+        "cli.js",
+        "auth",
+        "login",
+        "--environment",
+        "staging",
+      ];
 
       await main();
 
@@ -841,547 +939,717 @@ describe('CLI Integration Tests', () => {
     });
   });
 
-  describe('runs list with options', () => {
-    it('should support filtering by customMetadata', async () => {
-      process.argv = ['node', 'cli.js', 'runs', 'list', '--customMetadata', '$.key=value'];
-
-      await main();
-
-      expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Application runs:',
-        expect.stringContaining('run_id')
-      );
-    });
-
-    it('should support sort option', async () => {
-      process.argv = ['node', 'cli.js', 'runs', 'list', '--sort', '["run_id"]'];
-
-      await main();
-
-      expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Application runs:',
-        expect.stringContaining('run_id')
-      );
-    });
-
-    it('should support multiple filters combined', async () => {
+  describe("runs list with options", () => {
+    it("should support filtering by customMetadata", async () => {
       process.argv = [
-        'node',
-        'cli.js',
-        'runs',
-        'list',
-        '--applicationId',
-        'app1',
-        '--applicationVersion',
-        'v1.0.0',
-        '--sort',
-        '["-submitted_at"]',
+        "node",
+        "cli.js",
+        "runs",
+        "list",
+        "--customMetadata",
+        "$.key=value",
+        "--format",
+        "json",
       ];
 
       await main();
 
       expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Application runs:',
-        expect.stringContaining('run_id')
+        expect.stringContaining("run_id"),
+      );
+    });
+
+    it("should support sort option", async () => {
+      process.argv = [
+        "node",
+        "cli.js",
+        "runs",
+        "list",
+        "--sort",
+        '["run_id"]',
+        "--format",
+        "json",
+      ];
+
+      await main();
+
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        expect.stringContaining("run_id"),
+      );
+    });
+
+    it("should support multiple filters combined", async () => {
+      process.argv = [
+        "node",
+        "cli.js",
+        "runs",
+        "list",
+        "--applicationId",
+        "app1",
+        "--applicationVersion",
+        "v1.0.0",
+        "--sort",
+        '["-submitted_at"]',
+        "--format",
+        "json",
+      ];
+
+      await main();
+
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        expect.stringContaining("run_id"),
       );
     });
   });
 
-  describe('runs create with items', () => {
-    it('should create application run with items', async () => {
+  describe("runs create with items", () => {
+    it("should create application run with items", async () => {
       process.argv = [
-        'node',
-        'cli.js',
-        'runs',
-        'create',
-        'test-app',
-        'v1.0.0',
-        '--items',
+        "node",
+        "cli.js",
+        "runs",
+        "create",
+        "test-app",
+        "v1.0.0",
+        "--items",
         '[{"wsi_id": "wsi-123"}]',
+        "--format",
+        "json",
       ];
 
       await main();
 
       expect(consoleSpy.log).toHaveBeenCalledWith(
-        '✅ Application run created successfully:',
-        expect.stringContaining('run_id')
+        expect.stringContaining("run_id"),
       );
     });
 
-    it('should handle invalid items JSON', async () => {
+    it("should handle invalid items JSON", async () => {
       process.argv = [
-        'node',
-        'cli.js',
-        'runs',
-        'create',
-        'test-app',
-        'v1.0.0',
-        '--items',
-        'not-valid-json',
+        "node",
+        "cli.js",
+        "runs",
+        "create",
+        "test-app",
+        "v1.0.0",
+        "--items",
+        "not-valid-json",
       ];
 
       await main();
 
-      expect(consoleSpy.error).toHaveBeenCalledWith('❌ Invalid items JSON:', expect.any(Error));
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        "❌ Invalid items JSON:",
+        expect.any(Error),
+      );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
 
-    it('should handle non-array items JSON', async () => {
+    it("should handle non-array items JSON", async () => {
       process.argv = [
-        'node',
-        'cli.js',
-        'runs',
-        'create',
-        'test-app',
-        'v1.0.0',
-        '--items',
+        "node",
+        "cli.js",
+        "runs",
+        "create",
+        "test-app",
+        "v1.0.0",
+        "--items",
         '{"wsi_id": "wsi-123"}',
       ];
 
       await main();
 
-      expect(consoleSpy.error).toHaveBeenCalledWith('❌ Invalid items JSON:', expect.any(Error));
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        "❌ Invalid items JSON:",
+        expect.any(Error),
+      );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
 
-    it('should reject combining --items and --items-file', async () => {
+    it("should reject combining --items and --items-file", async () => {
       process.argv = [
-        'node',
-        'cli.js',
-        'runs',
-        'create',
-        'test-app',
-        'v1.0.0',
-        '--items',
-        '[]',
-        '--itemsFile',
-        './items.json',
+        "node",
+        "cli.js",
+        "runs",
+        "create",
+        "test-app",
+        "v1.0.0",
+        "--items",
+        "[]",
+        "--itemsFile",
+        "./items.json",
       ];
 
       await main();
 
-      expect(consoleSpy.error).toHaveBeenCalledWith(expect.stringContaining('mutually exclusive'));
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        expect.stringContaining("mutually exclusive"),
+      );
     });
 
-    it('should create application run with items piped via stdin', async () => {
+    it("should create application run with items piped via stdin", async () => {
       const stdinStream = Readable.from([
         Buffer.from('[{"wsi_id": "wsi-456"}]'),
       ]) as unknown as typeof process.stdin;
       stdinStream.isTTY = false;
       process.stdin = stdinStream;
 
-      process.argv = ['node', 'cli.js', 'runs', 'create', 'test-app', 'v1.0.0'];
+      process.argv = [
+        "node",
+        "cli.js",
+        "runs",
+        "create",
+        "test-app",
+        "v1.0.0",
+        "--format",
+        "json",
+      ];
 
       await main();
 
       expect(consoleSpy.log).toHaveBeenCalledWith(
-        '✅ Application run created successfully:',
-        expect.stringContaining('run_id')
+        expect.stringContaining("run_id"),
       );
     });
   });
 
-  describe('error handling', () => {
-    it('should handle API errors gracefully for test-api', async () => {
-      server.use(http.get('*/v1/applications', () => HttpResponse.error()));
+  describe("error handling", () => {
+    it("should handle API errors gracefully for test-api", async () => {
+      server.use(http.get("*/v1/applications", () => HttpResponse.error()));
 
-      process.argv = ['node', 'cli.js', 'test-api'];
-
-      await main();
-
-      expect(consoleSpy.error).toHaveBeenCalledWith('❌ API connection failed:', expect.any(Error));
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
-
-    it('should handle API errors for runs get', async () => {
-      server.use(http.get('*/v1/runs/:runId', () => HttpResponse.error()));
-
-      process.argv = ['node', 'cli.js', 'runs', 'get', 'run-1'];
-
-      await main();
-
-      expect(consoleSpy.error).toHaveBeenCalledWith('❌ Failed to get run:', expect.any(Error));
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
-
-    it('should handle API errors for runs cancel', async () => {
-      server.use(http.post('*/v1/runs/:runId/cancel', () => HttpResponse.error()));
-
-      process.argv = ['node', 'cli.js', 'runs', 'cancel', 'run-1'];
+      process.argv = ["node", "cli.js", "test-api"];
 
       await main();
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Failed to cancel application run:',
-        expect.any(Error)
+        "❌ API connection failed:",
+        expect.any(Error),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
 
-    it('should handle API errors for runs results list', async () => {
-      server.use(http.get('*/v1/runs/:runId/items', () => HttpResponse.error()));
+    it("should handle API errors for runs get", async () => {
+      server.use(http.get("*/v1/runs/:runId", () => HttpResponse.error()));
 
-      process.argv = ['node', 'cli.js', 'runs', 'results', 'list', 'run-1'];
+      process.argv = ["node", "cli.js", "runs", "get", "run-1"];
 
       await main();
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Failed to list run results:',
-        expect.any(Error)
+        "❌ Failed to get run:",
+        expect.any(Error),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
 
-    it('should handle API errors for runs results delete', async () => {
-      server.use(http.delete('*/v1/runs/:runId/artifacts', () => HttpResponse.error()));
-
-      process.argv = ['node', 'cli.js', 'runs', 'results', 'delete', 'run-1'];
-
-      await main();
-
-      expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Failed to delete run results:',
-        expect.any(Error)
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
-
-    it('should handle API errors for runs metadata set', async () => {
-      server.use(http.put('*/v1/runs/:runId/custom-metadata', () => HttpResponse.error()));
-
-      process.argv = ['node', 'cli.js', 'runs', 'metadata', 'set', 'run-1', '{}'];
-
-      await main();
-
-      expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Failed to update run metadata:',
-        expect.any(Error)
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
-
-    it('should handle invalid custom metadata JSON for runs metadata set', async () => {
-      process.argv = ['node', 'cli.js', 'runs', 'metadata', 'set', 'run-1', 'not-json'];
-
-      await main();
-
-      expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Invalid custom metadata JSON:',
-        expect.any(Error)
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
-
-    it('should handle API errors for runs items get', async () => {
-      server.use(http.get('*/v1/runs/:runId/items/:externalId', () => HttpResponse.error()));
-
-      process.argv = ['node', 'cli.js', 'runs', 'items', 'get', 'run-1', 'ext-1'];
-
-      await main();
-
-      expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Failed to get run item:',
-        expect.any(Error)
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
-
-    it('should handle API errors for runs items metadata set', async () => {
+    it("should handle API errors for runs cancel", async () => {
       server.use(
-        http.put('*/v1/runs/:runId/items/:externalId/custom-metadata', () => HttpResponse.error())
+        http.post("*/v1/runs/:runId/cancel", () => HttpResponse.error()),
       );
 
-      process.argv = ['node', 'cli.js', 'runs', 'items', 'metadata', 'set', 'run-1', 'ext-1', '{}'];
+      process.argv = ["node", "cli.js", "runs", "cancel", "run-1"];
 
       await main();
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Failed to update run item metadata:',
-        expect.any(Error)
+        "❌ Failed to cancel application run:",
+        expect.any(Error),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
 
-    it('should handle API errors for runs list', async () => {
-      server.use(http.get('*/v1/runs', () => HttpResponse.error()));
+    it("should handle API errors for runs results list", async () => {
+      server.use(
+        http.get("*/v1/runs/:runId/items", () => HttpResponse.error()),
+      );
 
-      process.argv = ['node', 'cli.js', 'runs', 'list'];
+      process.argv = ["node", "cli.js", "runs", "results", "list", "run-1"];
 
       await main();
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Failed to list application runs:',
-        expect.any(Error)
+        "❌ Failed to list run results:",
+        expect.any(Error),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
 
-    it('should handle API errors for runs create', async () => {
-      server.use(http.post('*/v1/runs', () => HttpResponse.error()));
+    it("should handle API errors for runs results delete", async () => {
+      server.use(
+        http.delete("*/v1/runs/:runId/artifacts", () => HttpResponse.error()),
+      );
 
-      process.argv = ['node', 'cli.js', 'runs', 'create', 'test-app', 'v1.0.0'];
+      process.argv = ["node", "cli.js", "runs", "results", "delete", "run-1"];
 
       await main();
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Failed to create application run:',
-        expect.any(Error)
+        "❌ Failed to delete run results:",
+        expect.any(Error),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
-  });
 
-  describe('grants create command', () => {
-    it('should create a grant successfully', async () => {
-      process.argv = [
-        'node',
-        'cli.js',
-        'grants',
-        'create',
-        '--resourceType',
-        'run',
-        '--resourceId',
-        'run-1',
-        '--subjectType',
-        'user',
-        '--subjectEmail',
-        'colleague@example.com',
-        '--relation',
-        'viewer',
-      ];
-
-      await main();
-
-      expect(consoleSpy.log).toHaveBeenCalledWith(
-        '✅ Grant created successfully:',
-        expect.stringContaining('grant_id')
+    it("should handle API errors for runs metadata set", async () => {
+      server.use(
+        http.put("*/v1/runs/:runId/custom-metadata", () =>
+          HttpResponse.error(),
+        ),
       );
-    });
-
-    it('should handle API errors for grants create', async () => {
-      server.use(http.post('*/v1/access/grants', () => HttpResponse.error()));
 
       process.argv = [
-        'node',
-        'cli.js',
-        'grants',
-        'create',
-        '--resourceType',
-        'run',
-        '--resourceId',
-        'run-1',
-        '--subjectType',
-        'user',
-        '--relation',
-        'viewer',
+        "node",
+        "cli.js",
+        "runs",
+        "metadata",
+        "set",
+        "run-1",
+        "{}",
       ];
 
       await main();
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Failed to create grant:',
-        expect.any(Error)
+        "❌ Failed to update run metadata:",
+        expect.any(Error),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
-  });
 
-  describe('grants list command', () => {
-    it('should list grants successfully', async () => {
-      process.argv = ['node', 'cli.js', 'grants', 'list', '--resourceId', 'run-1'];
-
-      await main();
-
-      expect(consoleSpy.log).toHaveBeenCalledWith('Grants:', expect.stringContaining('grant_id'));
-    });
-
-    it('should handle API errors for grants list', async () => {
-      server.use(http.get('*/v1/access/grants', () => HttpResponse.error()));
-
-      process.argv = ['node', 'cli.js', 'grants', 'list'];
-
-      await main();
-
-      expect(consoleSpy.error).toHaveBeenCalledWith('❌ Failed to list grants:', expect.any(Error));
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
-  });
-
-  describe('grants get command', () => {
-    it('should get grant details successfully', async () => {
-      process.argv = ['node', 'cli.js', 'grants', 'get', 'grant-1'];
-
-      await main();
-
-      expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Grant details for grant-1:',
-        expect.stringContaining('grant_id')
-      );
-    });
-
-    it('should handle API errors for grants get', async () => {
-      server.use(http.get('*/v1/access/grants/:grantId', () => HttpResponse.error()));
-
-      process.argv = ['node', 'cli.js', 'grants', 'get', 'grant-1'];
-
-      await main();
-
-      expect(consoleSpy.error).toHaveBeenCalledWith('❌ Failed to get grant:', expect.any(Error));
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
-  });
-
-  describe('grants revoke command', () => {
-    it('should revoke a grant successfully', async () => {
-      process.argv = ['node', 'cli.js', 'grants', 'revoke', 'grant-1'];
-
-      await main();
-
-      expect(consoleSpy.log).toHaveBeenCalledWith(
-        '✅ Grant revoked successfully:',
-        expect.stringContaining('grant_id')
-      );
-    });
-
-    it('should handle API errors for grants revoke', async () => {
-      server.use(http.delete('*/v1/access/grants/:grantId', () => HttpResponse.error()));
-
-      process.argv = ['node', 'cli.js', 'grants', 'revoke', 'grant-1'];
+    it("should handle invalid custom metadata JSON for runs metadata set", async () => {
+      process.argv = [
+        "node",
+        "cli.js",
+        "runs",
+        "metadata",
+        "set",
+        "run-1",
+        "not-json",
+      ];
 
       await main();
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Failed to revoke grant:',
-        expect.any(Error)
+        "❌ Invalid custom metadata JSON:",
+        expect.any(Error),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle API errors for runs items get", async () => {
+      server.use(
+        http.get("*/v1/runs/:runId/items/:externalId", () =>
+          HttpResponse.error(),
+        ),
+      );
+
+      process.argv = [
+        "node",
+        "cli.js",
+        "runs",
+        "items",
+        "get",
+        "run-1",
+        "ext-1",
+      ];
+
+      await main();
+
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        "❌ Failed to get run item:",
+        expect.any(Error),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle API errors for runs items metadata set", async () => {
+      server.use(
+        http.put("*/v1/runs/:runId/items/:externalId/custom-metadata", () =>
+          HttpResponse.error(),
+        ),
+      );
+
+      process.argv = [
+        "node",
+        "cli.js",
+        "runs",
+        "items",
+        "metadata",
+        "set",
+        "run-1",
+        "ext-1",
+        "{}",
+      ];
+
+      await main();
+
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        "❌ Failed to update run item metadata:",
+        expect.any(Error),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle API errors for runs list", async () => {
+      server.use(http.get("*/v1/runs", () => HttpResponse.error()));
+
+      process.argv = ["node", "cli.js", "runs", "list"];
+
+      await main();
+
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        "❌ Failed to list application runs:",
+        expect.any(Error),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle API errors for runs create", async () => {
+      server.use(http.post("*/v1/runs", () => HttpResponse.error()));
+
+      process.argv = ["node", "cli.js", "runs", "create", "test-app", "v1.0.0"];
+
+      await main();
+
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        "❌ Failed to create application run:",
+        expect.any(Error),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
   });
 
-  describe('share-tokens create command', () => {
-    it('should create a share token successfully', async () => {
+  describe("grants create command", () => {
+    it("should create a grant successfully", async () => {
       process.argv = [
-        'node',
-        'cli.js',
-        'share-tokens',
-        'create',
-        '--expiresAt',
-        '2026-01-01T00:00:00Z',
+        "node",
+        "cli.js",
+        "grants",
+        "create",
+        "--resourceType",
+        "run",
+        "--resourceId",
+        "run-1",
+        "--subjectType",
+        "user",
+        "--subjectEmail",
+        "colleague@example.com",
+        "--relation",
+        "viewer",
+        "--format",
+        "json",
       ];
 
       await main();
 
       expect(consoleSpy.log).toHaveBeenCalledWith(
-        '✅ Share token created successfully:',
-        expect.stringContaining('share_token')
+        expect.stringContaining("grant_id"),
       );
     });
 
-    it('should handle API errors for share-tokens create', async () => {
-      server.use(http.post('*/v1/access/share-tokens', () => HttpResponse.error()));
+    it("should handle API errors for grants create", async () => {
+      server.use(http.post("*/v1/access/grants", () => HttpResponse.error()));
 
-      process.argv = ['node', 'cli.js', 'share-tokens', 'create'];
+      process.argv = [
+        "node",
+        "cli.js",
+        "grants",
+        "create",
+        "--resourceType",
+        "run",
+        "--resourceId",
+        "run-1",
+        "--subjectType",
+        "user",
+        "--relation",
+        "viewer",
+      ];
 
       await main();
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Failed to create share token:',
-        expect.any(Error)
+        "❌ Failed to create grant:",
+        expect.any(Error),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
   });
 
-  describe('share-tokens list command', () => {
-    it('should list share tokens successfully', async () => {
-      process.argv = ['node', 'cli.js', 'share-tokens', 'list', '--runId', 'run-1'];
+  describe("grants list command", () => {
+    it("should list grants successfully", async () => {
+      process.argv = [
+        "node",
+        "cli.js",
+        "grants",
+        "list",
+        "--resourceId",
+        "run-1",
+        "--format",
+        "json",
+      ];
 
       await main();
 
       expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Share tokens:',
-        expect.stringContaining('share_token_id')
+        expect.stringContaining("grant_id"),
       );
     });
 
-    it('should handle API errors for share-tokens list', async () => {
-      server.use(http.get('*/v1/access/share-tokens', () => HttpResponse.error()));
+    it("should handle API errors for grants list", async () => {
+      server.use(http.get("*/v1/access/grants", () => HttpResponse.error()));
 
-      process.argv = ['node', 'cli.js', 'share-tokens', 'list'];
+      process.argv = ["node", "cli.js", "grants", "list"];
 
       await main();
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Failed to list share tokens:',
-        expect.any(Error)
+        "❌ Failed to list grants:",
+        expect.any(Error),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
   });
 
-  describe('share-tokens get command', () => {
-    it('should get share token details successfully', async () => {
-      process.argv = ['node', 'cli.js', 'share-tokens', 'get', 'share-token-1'];
+  describe("grants get command", () => {
+    it("should get grant details successfully", async () => {
+      process.argv = [
+        "node",
+        "cli.js",
+        "grants",
+        "get",
+        "grant-1",
+        "--format",
+        "json",
+      ];
 
       await main();
 
       expect(consoleSpy.log).toHaveBeenCalledWith(
-        'Share token details for share-token-1:',
-        expect.stringContaining('share_token_id')
+        expect.stringContaining("grant_id"),
       );
     });
 
-    it('should handle API errors for share-tokens get', async () => {
-      server.use(http.get('*/v1/access/share-tokens/:shareTokenId', () => HttpResponse.error()));
+    it("should handle API errors for grants get", async () => {
+      server.use(
+        http.get("*/v1/access/grants/:grantId", () => HttpResponse.error()),
+      );
 
-      process.argv = ['node', 'cli.js', 'share-tokens', 'get', 'share-token-1'];
+      process.argv = ["node", "cli.js", "grants", "get", "grant-1"];
 
       await main();
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Failed to get share token:',
-        expect.any(Error)
+        "❌ Failed to get grant:",
+        expect.any(Error),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
   });
 
-  describe('share-tokens revoke command', () => {
-    it('should revoke a share token successfully', async () => {
-      process.argv = ['node', 'cli.js', 'share-tokens', 'revoke', 'share-token-1'];
+  describe("grants revoke command", () => {
+    it("should revoke a grant successfully", async () => {
+      process.argv = [
+        "node",
+        "cli.js",
+        "grants",
+        "revoke",
+        "grant-1",
+        "--format",
+        "json",
+      ];
 
       await main();
 
       expect(consoleSpy.log).toHaveBeenCalledWith(
-        '✅ Share token revoked successfully:',
-        expect.stringContaining('share_token_id')
+        expect.stringContaining("grant_id"),
       );
     });
 
-    it('should handle API errors for share-tokens revoke', async () => {
-      server.use(http.delete('*/v1/access/share-tokens/:shareTokenId', () => HttpResponse.error()));
+    it("should handle API errors for grants revoke", async () => {
+      server.use(
+        http.delete("*/v1/access/grants/:grantId", () => HttpResponse.error()),
+      );
 
-      process.argv = ['node', 'cli.js', 'share-tokens', 'revoke', 'share-token-1'];
+      process.argv = ["node", "cli.js", "grants", "revoke", "grant-1"];
 
       await main();
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        '❌ Failed to revoke share token:',
-        expect.any(Error)
+        "❌ Failed to revoke grant:",
+        expect.any(Error),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
   });
 
-  describe('unknown command handling', () => {
-    it('should handle unknown command', async () => {
-      process.argv = ['node', 'cli.js', 'unknown-command'];
+  describe("share-tokens create command", () => {
+    it("should create a share token successfully", async () => {
+      process.argv = [
+        "node",
+        "cli.js",
+        "share-tokens",
+        "create",
+        "--expiresAt",
+        "2026-01-01T00:00:00Z",
+        "--format",
+        "json",
+      ];
+
+      await main();
+
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        expect.stringContaining("share_token"),
+      );
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        "⚠️  Save the share_token value now — it will not be shown again.",
+      );
+    });
+
+    it("should handle API errors for share-tokens create", async () => {
+      server.use(
+        http.post("*/v1/access/share-tokens", () => HttpResponse.error()),
+      );
+
+      process.argv = ["node", "cli.js", "share-tokens", "create"];
+
+      await main();
+
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        "❌ Failed to create share token:",
+        expect.any(Error),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("share-tokens list command", () => {
+    it("should list share tokens successfully", async () => {
+      process.argv = [
+        "node",
+        "cli.js",
+        "share-tokens",
+        "list",
+        "--runId",
+        "run-1",
+        "--format",
+        "json",
+      ];
+
+      await main();
+
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        expect.stringContaining("share_token_id"),
+      );
+    });
+
+    it("should handle API errors for share-tokens list", async () => {
+      server.use(
+        http.get("*/v1/access/share-tokens", () => HttpResponse.error()),
+      );
+
+      process.argv = ["node", "cli.js", "share-tokens", "list"];
+
+      await main();
+
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        "❌ Failed to list share tokens:",
+        expect.any(Error),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("share-tokens get command", () => {
+    it("should get share token details successfully", async () => {
+      process.argv = [
+        "node",
+        "cli.js",
+        "share-tokens",
+        "get",
+        "share-token-1",
+        "--format",
+        "json",
+      ];
+
+      await main();
+
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        expect.stringContaining("share_token_id"),
+      );
+    });
+
+    it("should handle API errors for share-tokens get", async () => {
+      server.use(
+        http.get("*/v1/access/share-tokens/:shareTokenId", () =>
+          HttpResponse.error(),
+        ),
+      );
+
+      process.argv = ["node", "cli.js", "share-tokens", "get", "share-token-1"];
+
+      await main();
+
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        "❌ Failed to get share token:",
+        expect.any(Error),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("share-tokens revoke command", () => {
+    it("should revoke a share token successfully", async () => {
+      process.argv = [
+        "node",
+        "cli.js",
+        "share-tokens",
+        "revoke",
+        "share-token-1",
+        "--format",
+        "json",
+      ];
+
+      await main();
+
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        expect.stringContaining("share_token_id"),
+      );
+    });
+
+    it("should handle API errors for share-tokens revoke", async () => {
+      server.use(
+        http.delete("*/v1/access/share-tokens/:shareTokenId", () =>
+          HttpResponse.error(),
+        ),
+      );
+
+      process.argv = [
+        "node",
+        "cli.js",
+        "share-tokens",
+        "revoke",
+        "share-token-1",
+      ];
+
+      await main();
+
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        "❌ Failed to revoke share token:",
+        expect.any(Error),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("unknown command handling", () => {
+    it("should handle unknown command", async () => {
+      process.argv = ["node", "cli.js", "unknown-command"];
 
       await main();
 
       expect(mockExit).toHaveBeenCalledWith(1);
       expect(consoleSpy.error).toHaveBeenCalledWith(
-        expect.stringContaining('Unknown argument: unknown-command')
+        expect.stringContaining("Unknown argument: unknown-command"),
       );
     });
   });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -41,7 +41,21 @@ import {
   type ResourceType,
   type SubjectType,
   type GrantRelation,
+  type GrantReadResponse,
+  type ShareTokenReadResponse,
+  type ShareTokenCreateResponse,
+  type ApplicationReadShortResponse,
+  type ApplicationReadResponse,
+  type ApplicationVersion,
+  type RunReadResponse,
+  type ItemResultReadResponse,
+  type VersionReadResponse,
+  type RunCreationResponse,
+  getRunStatus,
+  getRunProgress,
+  getItemStatus,
 } from '@aignostics/sdk';
+import { OutputFormat, format, printTable, printKeyValue } from './utils/formatting.js';
 
 // Create a shared auth service instance for the CLI
 const authService = new AuthService(new FileSystemTokenStorage());
@@ -87,6 +101,144 @@ function buildRunItemMetadataCommands(itemMetadataYargs: Argv) {
     .demandCommand(1, 'You need at least one metadata subcommand');
 }
 
+function printApplicationsTable(applications: ApplicationReadShortResponse[]): void {
+  printTable(
+    ['ID', 'Name', 'Latest Version'],
+    applications.map(app => [app.application_id, app.name, app.latest_version?.number ?? '-'])
+  );
+}
+
+function printApplicationDetails(application: ApplicationReadResponse): void {
+  printKeyValue([
+    ['Application ID', application.application_id],
+    ['Name', application.name],
+    ['Description', application.description],
+    ['Regulatory Classes', application.regulatory_classes.join(', ') || '-'],
+    ['Versions', application.versions.length],
+  ]);
+}
+
+function printApplicationVersionsTable(versions: ApplicationVersion[]): void {
+  printTable(
+    ['Number', 'Released At'],
+    versions.map(version => [version.number, version.released_at])
+  );
+}
+
+function printApplicationVersionDetails(version: VersionReadResponse): void {
+  printKeyValue([
+    ['Version Number', version.version_number],
+    ['Released At', version.released_at],
+    ['Changelog', version.changelog],
+    ['Input Artifacts', version.input_artifacts.length],
+    ['Output Artifacts', version.output_artifacts.length],
+  ]);
+}
+
+function printRunsTable(runs: RunReadResponse[]): void {
+  printTable(
+    ['Run ID', 'Application', 'Version', 'Status', 'Progress', 'Submitted At'],
+    runs.map(run => [
+      run.run_id,
+      run.application_id,
+      run.version_number,
+      getRunStatus(run),
+      `${getRunProgress(run)}%`,
+      run.submitted_at,
+    ])
+  );
+}
+
+function printRunDetails(run: RunReadResponse): void {
+  printKeyValue([
+    ['Run ID', run.run_id],
+    ['Application', run.application_id],
+    ['Version', run.version_number],
+    ['Status', getRunStatus(run)],
+    ['Progress', `${getRunProgress(run)}%`],
+    ['Submitted At', run.submitted_at],
+    ['Submitted By', run.submitted_by],
+  ]);
+}
+
+function printRunResultsTable(items: ItemResultReadResponse[]): void {
+  printTable(
+    ['External ID', 'Status'],
+    items.map(item => [item.external_id, getItemStatus(item)])
+  );
+}
+
+function printRunCreationResult(run: RunCreationResponse): void {
+  printKeyValue([['Run ID', run.run_id]]);
+}
+
+function printGrantsTable(grants: GrantReadResponse[]): void {
+  printTable(
+    [
+      'Grant ID',
+      'Resource Type',
+      'Resource ID',
+      'Subject Type',
+      'Subject ID',
+      'Relation',
+      'Revoked',
+    ],
+    grants.map(grant => [
+      grant.grant_id,
+      grant.resource_type,
+      grant.resource_id,
+      grant.subject_type,
+      grant.subject_id,
+      grant.relation,
+      String(grant.revoked),
+    ])
+  );
+}
+
+function printGrantDetails(grant: GrantReadResponse): void {
+  printKeyValue([
+    ['Grant ID', grant.grant_id],
+    ['Resource Type', grant.resource_type],
+    ['Resource ID', grant.resource_id],
+    ['Subject Type', grant.subject_type],
+    ['Subject ID', grant.subject_id],
+    ['Relation', grant.relation],
+    ['Created By', grant.created_by],
+    ['Created At', grant.created_at],
+    ['Revoked', String(grant.revoked)],
+  ]);
+}
+
+function printShareTokensTable(shareTokens: ShareTokenReadResponse[]): void {
+  printTable(
+    ['Share Token ID', 'Created At', 'Expires At', 'Revoked'],
+    shareTokens.map(shareToken => [
+      shareToken.share_token_id,
+      shareToken.created_at,
+      shareToken.expires_at ?? '-',
+      String(shareToken.revoked),
+    ])
+  );
+}
+
+function printShareTokenDetails(shareToken: ShareTokenReadResponse): void {
+  printKeyValue([
+    ['Share Token ID', shareToken.share_token_id],
+    ['Created At', shareToken.created_at],
+    ['Expires At', shareToken.expires_at ?? '-'],
+    ['Revoked', String(shareToken.revoked)],
+  ]);
+}
+
+function printShareTokenCreationResult(shareToken: ShareTokenCreateResponse): void {
+  printKeyValue([
+    ['Share Token ID', shareToken.share_token_id],
+    ['Share Token', shareToken.share_token],
+    ['Created At', shareToken.created_at],
+    ['Expires At', shareToken.expires_at ?? '-'],
+  ]);
+}
+
 /**
  * CLI for the Aignostics Platform SDK
  */
@@ -100,6 +252,12 @@ export async function main() {
       type: 'string',
       default: 'production',
       choices: Object.keys(environmentConfig),
+    })
+    .option('format', {
+      describe: 'Output format for command results',
+      type: 'string',
+      default: 'text',
+      choices: ['text', 'json'],
     })
     .command('info', 'Display SDK information', {}, handleInfo)
     .command(
@@ -122,7 +280,11 @@ export async function main() {
             yargs => yargs,
             argv => {
               const env = environmentSchema.parse(argv.environment);
-              return listApplications(env, authService);
+              return format(
+                argv.format as OutputFormat,
+                listApplications(env, authService),
+                printApplicationsTable
+              );
             }
           )
           .command(
@@ -136,7 +298,11 @@ export async function main() {
               }),
             argv => {
               const env = environmentSchema.parse(argv.environment);
-              return getApplicationDetails(env, authService, argv.applicationId);
+              return format(
+                argv.format as OutputFormat,
+                getApplicationDetails(env, authService, argv.applicationId),
+                printApplicationDetails
+              );
             }
           )
           .command(
@@ -155,7 +321,11 @@ export async function main() {
                     }),
                   argv => {
                     const env = environmentSchema.parse(argv.environment);
-                    return listApplicationVersions(env, authService, argv.applicationId);
+                    return format(
+                      argv.format as OutputFormat,
+                      listApplicationVersions(env, authService, argv.applicationId),
+                      printApplicationVersionsTable
+                    );
                   }
                 )
                 .command(
@@ -175,11 +345,15 @@ export async function main() {
                       }),
                   argv => {
                     const env = environmentSchema.parse(argv.environment);
-                    return getApplicationVersionDetails(
-                      env,
-                      authService,
-                      argv.applicationId,
-                      argv.versionNumber
+                    return format(
+                      argv.format as OutputFormat,
+                      getApplicationVersionDetails(
+                        env,
+                        authService,
+                        argv.applicationId,
+                        argv.versionNumber
+                      ),
+                      printApplicationVersionDetails
                     );
                   }
                 )
@@ -224,12 +398,16 @@ export async function main() {
                 items: argv.items,
                 itemsFile: argv.itemsFile,
               });
-              return createApplicationRun(
-                env,
-                authService,
-                argv.applicationId,
-                argv.versionNumber,
-                itemsJson
+              return format(
+                argv.format as OutputFormat,
+                createApplicationRun(
+                  env,
+                  authService,
+                  argv.applicationId,
+                  argv.versionNumber,
+                  itemsJson
+                ),
+                printRunCreationResult
               );
             }
           )
@@ -257,12 +435,16 @@ export async function main() {
                 }),
             argv => {
               const env = environmentSchema.parse(argv.environment);
-              return listApplicationRuns(env, authService, {
-                applicationId: argv.applicationId,
-                applicationVersion: argv.applicationVersion,
-                customMetadata: argv.customMetadata,
-                sort: argv.sort,
-              });
+              return format(
+                argv.format as OutputFormat,
+                listApplicationRuns(env, authService, {
+                  applicationId: argv.applicationId,
+                  applicationVersion: argv.applicationVersion,
+                  customMetadata: argv.customMetadata,
+                  sort: argv.sort,
+                }),
+                printRunsTable
+              );
             }
           )
           .command(
@@ -276,7 +458,11 @@ export async function main() {
               }),
             argv => {
               const env = environmentSchema.parse(argv.environment);
-              return getRun(env, authService, argv.applicationRunId);
+              return format(
+                argv.format as OutputFormat,
+                getRun(env, authService, argv.applicationRunId),
+                printRunDetails
+              );
             }
           )
           .command(
@@ -342,7 +528,11 @@ export async function main() {
                     }),
                   argv => {
                     const env = environmentSchema.parse(argv.environment);
-                    return listRunResults(env, authService, argv.applicationRunId);
+                    return format(
+                      argv.format as OutputFormat,
+                      listRunResults(env, authService, argv.applicationRunId),
+                      printRunResultsTable
+                    );
                   }
                 )
                 .command(
@@ -442,14 +632,18 @@ export async function main() {
                 }),
             argv => {
               const env = environmentSchema.parse(argv.environment);
-              return createGrant(env, authService, {
-                resourceType: argv.resourceType as ResourceType,
-                resourceId: argv.resourceId,
-                subjectType: argv.subjectType as SubjectType,
-                subjectId: argv.subjectId,
-                subjectEmail: argv.subjectEmail,
-                relation: argv.relation as GrantRelation,
-              });
+              return format(
+                argv.format as OutputFormat,
+                createGrant(env, authService, {
+                  resourceType: argv.resourceType as ResourceType,
+                  resourceId: argv.resourceId,
+                  subjectType: argv.subjectType as SubjectType,
+                  subjectId: argv.subjectId,
+                  subjectEmail: argv.subjectEmail,
+                  relation: argv.relation as GrantRelation,
+                }),
+                printGrantDetails
+              );
             }
           )
           .command(
@@ -485,14 +679,18 @@ export async function main() {
                 }),
             argv => {
               const env = environmentSchema.parse(argv.environment);
-              return listGrants(env, authService, {
-                resourceType: argv.resourceType as ResourceType | undefined,
-                resourceId: argv.resourceId,
-                subjectType: argv.subjectType as SubjectType | undefined,
-                subjectId: argv.subjectId,
-                revoked: argv.revoked,
-                sort: argv.sort,
-              });
+              return format(
+                argv.format as OutputFormat,
+                listGrants(env, authService, {
+                  resourceType: argv.resourceType as ResourceType | undefined,
+                  resourceId: argv.resourceId,
+                  subjectType: argv.subjectType as SubjectType | undefined,
+                  subjectId: argv.subjectId,
+                  revoked: argv.revoked,
+                  sort: argv.sort,
+                }),
+                printGrantsTable
+              );
             }
           )
           .command(
@@ -506,7 +704,11 @@ export async function main() {
               }),
             argv => {
               const env = environmentSchema.parse(argv.environment);
-              return getGrant(env, authService, argv.grantId);
+              return format(
+                argv.format as OutputFormat,
+                getGrant(env, authService, argv.grantId),
+                printGrantDetails
+              );
             }
           )
           .command(
@@ -520,7 +722,11 @@ export async function main() {
               }),
             argv => {
               const env = environmentSchema.parse(argv.environment);
-              return revokeGrant(env, authService, argv.grantId);
+              return format(
+                argv.format as OutputFormat,
+                revokeGrant(env, authService, argv.grantId),
+                printGrantDetails
+              );
             }
           )
           .demandCommand(1, 'You need at least one grants subcommand'),
@@ -541,9 +747,13 @@ export async function main() {
               }),
             argv => {
               const env = environmentSchema.parse(argv.environment);
-              return createShareToken(env, authService, {
-                expiresAt: argv.expiresAt,
-              });
+              return format(
+                argv.format as OutputFormat,
+                createShareToken(env, authService, {
+                  expiresAt: argv.expiresAt,
+                }),
+                printShareTokenCreationResult
+              );
             }
           )
           .command(
@@ -569,12 +779,16 @@ export async function main() {
                 }),
             argv => {
               const env = environmentSchema.parse(argv.environment);
-              return listShareTokens(env, authService, {
-                runId: argv.runId,
-                createdBy: argv.createdBy,
-                revoked: argv.revoked,
-                sort: argv.sort,
-              });
+              return format(
+                argv.format as OutputFormat,
+                listShareTokens(env, authService, {
+                  runId: argv.runId,
+                  createdBy: argv.createdBy,
+                  revoked: argv.revoked,
+                  sort: argv.sort,
+                }),
+                printShareTokensTable
+              );
             }
           )
           .command(
@@ -588,7 +802,11 @@ export async function main() {
               }),
             argv => {
               const env = environmentSchema.parse(argv.environment);
-              return getShareToken(env, authService, argv.shareTokenId);
+              return format(
+                argv.format as OutputFormat,
+                getShareToken(env, authService, argv.shareTokenId),
+                printShareTokenDetails
+              );
             }
           )
           .command(
@@ -602,7 +820,11 @@ export async function main() {
               }),
             argv => {
               const env = environmentSchema.parse(argv.environment);
-              return revokeShareToken(env, authService, argv.shareTokenId);
+              return format(
+                argv.format as OutputFormat,
+                revokeShareToken(env, authService, argv.shareTokenId),
+                printShareTokenDetails
+              );
             }
           )
           .demandCommand(1, 'You need at least one share-tokens subcommand'),

--- a/packages/cli/src/utils/formatting.spec.ts
+++ b/packages/cli/src/utils/formatting.spec.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from 'vitest';
+import { printJson, printKeyValue, printTable, printResult } from './formatting.js';
+
+describe('formatting utils', () => {
+  describe('printJson', () => {
+    it('prints pretty-printed JSON', () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      printJson({ a: 1, b: 'two' });
+
+      expect(logSpy).toHaveBeenCalledWith(JSON.stringify({ a: 1, b: 'two' }, null, 2));
+      logSpy.mockRestore();
+    });
+  });
+
+  describe('printKeyValue', () => {
+    it('prints one `Key: value` line per pair', () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      printKeyValue([
+        ['Name', 'Alice'],
+        ['Age', 30],
+      ]);
+
+      expect(logSpy).toHaveBeenCalledWith('Name: Alice');
+      expect(logSpy).toHaveBeenCalledWith('Age: 30');
+      logSpy.mockRestore();
+    });
+  });
+
+  describe('printTable', () => {
+    it('renders a table containing the headers and row values', () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      printTable(
+        ['Name', 'Age'],
+        [
+          ['Alice', 30],
+          ['Bob', 25],
+        ]
+      );
+
+      const output = logSpy.mock.calls[0][0] as string;
+      expect(output).toContain('Name');
+      expect(output).toContain('Age');
+      expect(output).toContain('Alice');
+      expect(output).toContain('Bob');
+      logSpy.mockRestore();
+    });
+  });
+
+  describe('printResult', () => {
+    it('delegates to the text printer for the "text" format', () => {
+      const textPrinter = vi.fn();
+
+      printResult('text', { a: 1 }, textPrinter);
+
+      expect(textPrinter).toHaveBeenCalledWith({ a: 1 });
+    });
+
+    it('prints JSON directly for the "json" format, ignoring the text printer', () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const textPrinter = vi.fn();
+
+      printResult('json', { a: 1 }, textPrinter);
+
+      expect(textPrinter).not.toHaveBeenCalled();
+      expect(logSpy).toHaveBeenCalledWith(JSON.stringify({ a: 1 }, null, 2));
+      logSpy.mockRestore();
+    });
+  });
+});

--- a/packages/cli/src/utils/formatting.ts
+++ b/packages/cli/src/utils/formatting.ts
@@ -1,0 +1,60 @@
+import Table from 'cli-table3';
+
+/** Output format for CLI command results: human-friendly text (default) or raw JSON. */
+export type OutputFormat = 'text' | 'json';
+
+/** Print data as pretty-printed JSON. */
+export function printJson(data: unknown): void {
+  console.log(JSON.stringify(data, null, 2));
+}
+
+/** Print rows as an aligned text table with the given column headers. */
+export function printTable(head: string[], rows: (string | number)[][]): void {
+  const table = new Table({ head });
+  table.push(...rows);
+  console.log(table.toString());
+}
+
+/** Print a single resource as a list of `Key: value` lines. */
+export function printKeyValue(pairs: [string, string | number][]): void {
+  for (const [key, value] of pairs) {
+    console.log(`${key}: ${value}`);
+  }
+}
+
+/**
+ * Print `data` in the requested format: raw JSON when `format` is `'json'`,
+ * otherwise delegate to `printText` for human-friendly output.
+ */
+export function printResult<T>(format: OutputFormat, data: T, printText: (data: T) => void): void {
+  if (format === 'json') {
+    printJson(data);
+  } else {
+    printText(data);
+  }
+}
+
+/**
+ * Compose fetching and printing: awaits `data` (typically a call to a
+ * format-agnostic CLI function) and prints the resolved value in the
+ * requested format. If `data` resolves to `undefined` (the CLI function
+ * already reported an error and is about to exit), nothing is printed.
+ *
+ * @example
+ * ```typescript
+ * return format(argv.format as OutputFormat, listApplications(env, authService), applications =>
+ *   printTable(['ID', 'Name'], applications.map(app => [app.application_id, app.name]))
+ * );
+ * ```
+ */
+export async function format<T>(
+  outputFormat: OutputFormat,
+  data: Promise<T | undefined> | T | undefined,
+  printText: (data: T) => void
+): Promise<void> {
+  const resolved = await data;
+  if (resolved === undefined) {
+    return;
+  }
+  printResult(outputFormat, resolved, printText);
+}


### PR DESCRIPTION
## Summary

Adds a `--format <text|json>` option (default `text`) to all read/mutation CLI commands, similar to kubectl's `-o` convention:

- `text` (default): human-friendly table (via `cli-table3`) for list commands, and a concise key/value summary for single-resource get/create commands. Only the most relevant fields are shown.
- `json`: full raw response, unchanged from prior behavior — for scripting.

## Architecture

- `cli-functions.ts` is now **format-agnostic**: each function fetches data via the SDK and returns it (or `undefined` after reporting an error and exiting), instead of printing the result itself.
- `utils/formatting.ts` adds a `format(outputFormat, dataPromise, textPrinter)` composer that awaits the data and either prints raw JSON or delegates to a text printer, skipping printing if the data resolved to `undefined`.
- `cli.ts` composes fetching + formatting per command using named top-level printer functions (e.g. `printApplicationsTable`, `printRunDetails`) to keep nesting shallow.

## Changes

- `packages/cli/src/utils/formatting.ts` (new): `printJson`, `printTable`, `printKeyValue`, `printResult`, `format`.
- `packages/cli/src/cli-functions.ts`: dropped output/formatting responsibility, functions return data.
- `packages/cli/src/cli.ts`: composes `format()` + named printers per command; added global `--format` option.
- `packages/cli/package.json`: added `cli-table3` (MIT, well-established table rendering library).
- Updated `packages/cli/README.md` with `--format` usage.
- Updated unit tests (`cli-functions.spec.ts`, `cli.test.ts`) and added `utils/formatting.spec.ts`.

## Testing

- `npm run test --workspace @aignostics/cli` — 176 tests passing
- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run build` — clean

Refs: TSSDK-70
