### PR TITLE
feat(sdk): add support for access grants and share tokens

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -12754,7 +12754,7 @@ SOFTWARE.
 
 ## flatted
 
-**Version:** 3.4.2  
+**Version:** 3.4.3  
 **License:** ISC
 
 ```
@@ -15706,7 +15706,7 @@ SOFTWARE.
 
 ## mdurl
 
-**Version:** 2.0.0  
+**Version:** 2.1.0  
 **License:** MIT
 
 ```

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -84,6 +84,34 @@ aignostics-platform runs metadata set <applicationRunId> '{"note": "Reviewed by 
 aignostics-platform runs items metadata set <applicationRunId> <externalId> '{"reviewed": true}'
 ```
 
+### Access Grants & Share Tokens
+
+```bash
+# Grant a user access to a run
+aignostics-platform grants create --resourceType run --resourceId <runId> --subjectType user --subjectEmail colleague@example.com --relation viewer
+
+# List grants, optionally filtered
+aignostics-platform grants list --resourceType run --resourceId <runId>
+
+# Get details of a specific grant
+aignostics-platform grants get <grantId>
+
+# Revoke a grant
+aignostics-platform grants revoke <grantId>
+
+# Create a share token (the token value is shown only once)
+aignostics-platform share-tokens create --expiresAt 2026-01-01T00:00:00Z
+
+# List share tokens, optionally filtered
+aignostics-platform share-tokens list --runId <runId>
+
+# Get details of a specific share token
+aignostics-platform share-tokens get <shareTokenId>
+
+# Revoke a share token
+aignostics-platform share-tokens revoke <shareTokenId>
+```
+
 ## Commands
 
 - `info` - Display CLI version information
@@ -91,5 +119,7 @@ aignostics-platform runs items metadata set <applicationRunId> <externalId> '{"r
 - `auth` - `login`, `logout`, `status`
 - `applications` - `list`, `get`, `versions list`, `versions get`
 - `runs` - `create`, `list`, `get`, `cancel`, `metadata set`, `results list`, `results delete`, `items get`, `items metadata set`
+- `grants` - `create`, `list`, `get`, `revoke`
+- `share-tokens` - `create`, `list`, `get`, `revoke`
 
 For detailed usage information, use `aignostics-platform --help` or `aignostics-platform <command> --help`.

--- a/packages/cli/src/cli-functions.spec.ts
+++ b/packages/cli/src/cli-functions.spec.ts
@@ -21,6 +21,14 @@ import {
   handleLogout,
   handleStatus,
   handleLoginWithRefreshToken,
+  createGrant,
+  listGrants,
+  getGrant,
+  revokeGrant,
+  createShareToken,
+  listShareTokens,
+  getShareToken,
+  revokeShareToken,
 } from './cli-functions.js';
 import { PlatformSDK, PlatformSDKHttp } from '@aignostics/sdk';
 import { AuthService, AuthState } from './utils/auth.js';
@@ -64,6 +72,16 @@ const platformSDKMock = {
   getConfig: vi.fn(),
   getVersion: vi.fn(),
   getApplication: vi.fn(),
+  createGrant: vi.fn(),
+  listGrants: vi.fn(),
+  getGrant: vi.fn(),
+  revokeGrant: vi.fn(),
+  createShareToken: vi.fn(),
+  listShareTokens: vi.fn(),
+  getShareToken: vi.fn(),
+  revokeShareToken: vi.fn(),
+  downloadArtifact: vi.fn(),
+  downloadArtifactStream: vi.fn(),
 } satisfies PlatformSDK;
 
 // Mock AuthService
@@ -750,6 +768,60 @@ describe('CLI Functions Unit Tests', () => {
       expect(mockExit).toHaveBeenCalledWith(1);
     });
   });
+  describe('createGrant', () => {
+    it('should create a grant successfully', async () => {
+      const grantResponse = {
+        grant_id: 'grant-1',
+        resource_type: 'run',
+        resource_id: 'run-1',
+        subject_type: 'user',
+        subject_id: 'user-1',
+        relation: 'viewer',
+        created_by: 'user-2',
+        created_at: '2023-01-01T00:00:00Z',
+        revoked: false,
+      };
+      platformSDKMock.createGrant.mockResolvedValue(grantResponse);
+
+      await createGrant('production', mockAuthService, {
+        resourceType: 'run',
+        resourceId: 'run-1',
+        subjectType: 'user',
+        subjectEmail: 'colleague@example.com',
+        relation: 'viewer',
+      });
+
+      expect(platformSDKMock.createGrant).toHaveBeenCalledWith({
+        resource_type: 'run',
+        resource_id: 'run-1',
+        subject_type: 'user',
+        subject_id: undefined,
+        subject_email: 'colleague@example.com',
+        relation: 'viewer',
+      });
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        '✅ Grant created successfully:',
+        JSON.stringify(grantResponse, null, 2)
+      );
+    });
+
+    it('should handle API error', async () => {
+      platformSDKMock.createGrant.mockRejectedValue(new Error('API error'));
+
+      await createGrant('production', mockAuthService, {
+        resourceType: 'run',
+        resourceId: 'run-1',
+        subjectType: 'user',
+        relation: 'viewer',
+      });
+
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        '❌ Failed to create grant:',
+        expect.any(Error)
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
 
   describe('deleteRunResults', () => {
     it('should delete run results successfully', async () => {
@@ -768,6 +840,242 @@ describe('CLI Functions Unit Tests', () => {
 
       expect(consoleSpy.error).toHaveBeenCalledWith(
         '❌ Failed to delete run results:',
+        expect.any(Error)
+      );
+    });
+  });
+
+  describe('listGrants', () => {
+    it('should list grants successfully', async () => {
+      const grantsResponse = [
+        {
+          grant_id: 'grant-1',
+          resource_type: 'run',
+          resource_id: 'run-1',
+          subject_type: 'user',
+          subject_id: 'user-1',
+          relation: 'viewer',
+          created_by: 'user-2',
+          created_at: '2023-01-01T00:00:00Z',
+          revoked: false,
+        },
+      ];
+      platformSDKMock.listGrants.mockResolvedValue(grantsResponse);
+
+      await listGrants('production', mockAuthService, { resourceId: 'run-1' });
+
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        'Grants:',
+        JSON.stringify(grantsResponse, null, 2)
+      );
+    });
+
+    it('should handle API error', async () => {
+      platformSDKMock.listGrants.mockRejectedValue(new Error('API error'));
+
+      await listGrants('production', mockAuthService);
+
+      expect(consoleSpy.error).toHaveBeenCalledWith('❌ Failed to list grants:', expect.any(Error));
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('getGrant', () => {
+    it('should get grant details successfully', async () => {
+      const grantResponse = {
+        grant_id: 'grant-1',
+        resource_type: 'run',
+        resource_id: 'run-1',
+        subject_type: 'user',
+        subject_id: 'user-1',
+        relation: 'viewer',
+        created_by: 'user-2',
+        created_at: '2023-01-01T00:00:00Z',
+        revoked: false,
+      };
+      platformSDKMock.getGrant.mockResolvedValue(grantResponse);
+
+      await getGrant('production', mockAuthService, 'grant-1');
+
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        'Grant details for grant-1:',
+        JSON.stringify(grantResponse, null, 2)
+      );
+    });
+
+    it('should handle API error', async () => {
+      platformSDKMock.getGrant.mockRejectedValue(new Error('API error'));
+
+      await getGrant('production', mockAuthService, 'grant-1');
+
+      expect(consoleSpy.error).toHaveBeenCalledWith('❌ Failed to get grant:', expect.any(Error));
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('revokeGrant', () => {
+    it('should revoke a grant successfully', async () => {
+      const grantResponse = {
+        grant_id: 'grant-1',
+        resource_type: 'run',
+        resource_id: 'run-1',
+        subject_type: 'user',
+        subject_id: 'user-1',
+        relation: 'viewer',
+        created_by: 'user-2',
+        created_at: '2023-01-01T00:00:00Z',
+        revoked: true,
+      };
+      platformSDKMock.revokeGrant.mockResolvedValue(grantResponse);
+
+      await revokeGrant('production', mockAuthService, 'grant-1');
+
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        '✅ Grant revoked successfully:',
+        JSON.stringify(grantResponse, null, 2)
+      );
+    });
+
+    it('should handle API error', async () => {
+      platformSDKMock.revokeGrant.mockRejectedValue(new Error('API error'));
+
+      await revokeGrant('production', mockAuthService, 'grant-1');
+
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        '❌ Failed to revoke grant:',
+        expect.any(Error)
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('createShareToken', () => {
+    it('should create a share token successfully', async () => {
+      const shareTokenResponse = {
+        share_token_id: 'share-token-1',
+        share_token: 'secret-value',
+        created_at: '2023-01-01T00:00:00Z',
+        expires_at: null,
+        revoked: false,
+      };
+      platformSDKMock.createShareToken.mockResolvedValue(shareTokenResponse);
+
+      await createShareToken('production', mockAuthService, { expiresAt: '2026-01-01T00:00:00Z' });
+
+      expect(platformSDKMock.createShareToken).toHaveBeenCalledWith({
+        expires_at: '2026-01-01T00:00:00Z',
+      });
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        '✅ Share token created successfully:',
+        JSON.stringify(shareTokenResponse, null, 2)
+      );
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        '⚠️  Save the share_token value now — it will not be shown again.'
+      );
+    });
+
+    it('should handle API error', async () => {
+      platformSDKMock.createShareToken.mockRejectedValue(new Error('API error'));
+
+      await createShareToken('production', mockAuthService);
+
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        '❌ Failed to create share token:',
+        expect.any(Error)
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('listShareTokens', () => {
+    it('should list share tokens successfully', async () => {
+      const shareTokensResponse = [
+        {
+          share_token_id: 'share-token-1',
+          created_at: '2023-01-01T00:00:00Z',
+          expires_at: null,
+          revoked: false,
+        },
+      ];
+      platformSDKMock.listShareTokens.mockResolvedValue(shareTokensResponse);
+
+      await listShareTokens('production', mockAuthService, { runId: 'run-1' });
+
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        'Share tokens:',
+        JSON.stringify(shareTokensResponse, null, 2)
+      );
+    });
+
+    it('should handle API error', async () => {
+      platformSDKMock.listShareTokens.mockRejectedValue(new Error('API error'));
+
+      await listShareTokens('production', mockAuthService);
+
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        '❌ Failed to list share tokens:',
+        expect.any(Error)
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('getShareToken', () => {
+    it('should get share token details successfully', async () => {
+      const shareTokenResponse = {
+        share_token_id: 'share-token-1',
+        created_at: '2023-01-01T00:00:00Z',
+        expires_at: null,
+        revoked: false,
+      };
+      platformSDKMock.getShareToken.mockResolvedValue(shareTokenResponse);
+
+      await getShareToken('production', mockAuthService, 'share-token-1');
+
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        'Share token details for share-token-1:',
+        JSON.stringify(shareTokenResponse, null, 2)
+      );
+    });
+
+    it('should handle API error', async () => {
+      platformSDKMock.getShareToken.mockRejectedValue(new Error('API error'));
+
+      await getShareToken('production', mockAuthService, 'share-token-1');
+
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        '❌ Failed to get share token:',
+        expect.any(Error)
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('revokeShareToken', () => {
+    it('should revoke a share token successfully', async () => {
+      const shareTokenResponse = {
+        share_token_id: 'share-token-1',
+        created_at: '2023-01-01T00:00:00Z',
+        expires_at: null,
+        revoked: true,
+      };
+      platformSDKMock.revokeShareToken.mockResolvedValue(shareTokenResponse);
+
+      await revokeShareToken('production', mockAuthService, 'share-token-1');
+
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        '✅ Share token revoked successfully:',
+        JSON.stringify(shareTokenResponse, null, 2)
+      );
+    });
+
+    it('should handle API error', async () => {
+      platformSDKMock.revokeShareToken.mockRejectedValue(new Error('API error'));
+
+      await revokeShareToken('production', mockAuthService, 'share-token-1');
+
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        '❌ Failed to revoke share token:',
         expect.any(Error)
       );
       expect(mockExit).toHaveBeenCalledWith(1);

--- a/packages/cli/src/cli-functions.ts
+++ b/packages/cli/src/cli-functions.ts
@@ -1,4 +1,10 @@
-import { PlatformSDKHttp, type ItemCreationRequest } from '@aignostics/sdk';
+import {
+  PlatformSDKHttp,
+  type ItemCreationRequest,
+  type GrantRelation,
+  type ResourceType,
+  type SubjectType,
+} from '@aignostics/sdk';
 import { AuthService, type LoginWithCallbackConfig } from './utils/auth.js';
 import { startCallbackServer, waitForCallback } from './utils/oauth-callback-server.js';
 import { readFileSync } from 'fs';
@@ -495,6 +501,201 @@ export async function handleStatus(
     }
   } catch (error) {
     console.error('❌ Error checking status:', error);
+    process.exit(1);
+  }
+}
+
+export async function createGrant(
+  environment: EnvironmentKey,
+  authService: AuthService,
+  options: {
+    resourceType: ResourceType;
+    resourceId: string;
+    subjectType: SubjectType;
+    subjectId?: string;
+    subjectEmail?: string;
+    relation: GrantRelation;
+  }
+): Promise<void> {
+  const { endpoint } = environmentConfig[environment];
+  const sdk = new PlatformSDKHttp({
+    baseURL: endpoint,
+    tokenProvider: () => authService.getValidAccessToken(environment),
+  });
+  try {
+    const response = await sdk.createGrant({
+      resource_type: options.resourceType,
+      resource_id: options.resourceId,
+      subject_type: options.subjectType,
+      subject_id: options.subjectId,
+      subject_email: options.subjectEmail,
+      relation: options.relation,
+    });
+    console.log('✅ Grant created successfully:', JSON.stringify(response, null, 2));
+  } catch (error) {
+    console.error('❌ Failed to create grant:', error);
+    process.exit(1);
+  }
+}
+
+export async function listGrants(
+  environment: EnvironmentKey,
+  authService: AuthService,
+  options?: {
+    resourceType?: ResourceType;
+    resourceId?: string;
+    subjectType?: SubjectType;
+    subjectId?: string;
+    revoked?: boolean;
+    sort?: string;
+  }
+): Promise<void> {
+  const { endpoint } = environmentConfig[environment];
+  const sdk = new PlatformSDKHttp({
+    baseURL: endpoint,
+    tokenProvider: () => authService.getValidAccessToken(environment),
+  });
+  try {
+    const response = await sdk.listGrants({
+      resourceType: options?.resourceType,
+      resourceId: options?.resourceId,
+      subjectType: options?.subjectType,
+      subjectId: options?.subjectId,
+      revoked: options?.revoked,
+      sort: options?.sort ? [options.sort] : undefined,
+    });
+    console.log('Grants:', JSON.stringify(response, null, 2));
+  } catch (error) {
+    console.error('❌ Failed to list grants:', error);
+    process.exit(1);
+  }
+}
+
+export async function getGrant(
+  environment: EnvironmentKey,
+  authService: AuthService,
+  grantId: string
+): Promise<void> {
+  const { endpoint } = environmentConfig[environment];
+  const sdk = new PlatformSDKHttp({
+    baseURL: endpoint,
+    tokenProvider: () => authService.getValidAccessToken(environment),
+  });
+  try {
+    const response = await sdk.getGrant(grantId);
+    console.log(`Grant details for ${grantId}:`, JSON.stringify(response, null, 2));
+  } catch (error) {
+    console.error('❌ Failed to get grant:', error);
+    process.exit(1);
+  }
+}
+
+export async function revokeGrant(
+  environment: EnvironmentKey,
+  authService: AuthService,
+  grantId: string
+): Promise<void> {
+  const { endpoint } = environmentConfig[environment];
+  const sdk = new PlatformSDKHttp({
+    baseURL: endpoint,
+    tokenProvider: () => authService.getValidAccessToken(environment),
+  });
+  try {
+    const response = await sdk.revokeGrant(grantId);
+    console.log(`✅ Grant revoked successfully:`, JSON.stringify(response, null, 2));
+  } catch (error) {
+    console.error('❌ Failed to revoke grant:', error);
+    process.exit(1);
+  }
+}
+
+export async function createShareToken(
+  environment: EnvironmentKey,
+  authService: AuthService,
+  options?: {
+    expiresAt?: string;
+  }
+): Promise<void> {
+  const { endpoint } = environmentConfig[environment];
+  const sdk = new PlatformSDKHttp({
+    baseURL: endpoint,
+    tokenProvider: () => authService.getValidAccessToken(environment),
+  });
+  try {
+    const response = await sdk.createShareToken({
+      expires_at: options?.expiresAt,
+    });
+    console.log('✅ Share token created successfully:', JSON.stringify(response, null, 2));
+    console.log('⚠️  Save the share_token value now — it will not be shown again.');
+  } catch (error) {
+    console.error('❌ Failed to create share token:', error);
+    process.exit(1);
+  }
+}
+
+export async function listShareTokens(
+  environment: EnvironmentKey,
+  authService: AuthService,
+  options?: {
+    runId?: string;
+    createdBy?: string;
+    revoked?: boolean;
+    sort?: string;
+  }
+): Promise<void> {
+  const { endpoint } = environmentConfig[environment];
+  const sdk = new PlatformSDKHttp({
+    baseURL: endpoint,
+    tokenProvider: () => authService.getValidAccessToken(environment),
+  });
+  try {
+    const response = await sdk.listShareTokens({
+      runId: options?.runId,
+      createdBy: options?.createdBy,
+      revoked: options?.revoked,
+      sort: options?.sort ? [options.sort] : undefined,
+    });
+    console.log('Share tokens:', JSON.stringify(response, null, 2));
+  } catch (error) {
+    console.error('❌ Failed to list share tokens:', error);
+    process.exit(1);
+  }
+}
+
+export async function getShareToken(
+  environment: EnvironmentKey,
+  authService: AuthService,
+  shareTokenId: string
+): Promise<void> {
+  const { endpoint } = environmentConfig[environment];
+  const sdk = new PlatformSDKHttp({
+    baseURL: endpoint,
+    tokenProvider: () => authService.getValidAccessToken(environment),
+  });
+  try {
+    const response = await sdk.getShareToken(shareTokenId);
+    console.log(`Share token details for ${shareTokenId}:`, JSON.stringify(response, null, 2));
+  } catch (error) {
+    console.error('❌ Failed to get share token:', error);
+    process.exit(1);
+  }
+}
+
+export async function revokeShareToken(
+  environment: EnvironmentKey,
+  authService: AuthService,
+  shareTokenId: string
+): Promise<void> {
+  const { endpoint } = environmentConfig[environment];
+  const sdk = new PlatformSDKHttp({
+    baseURL: endpoint,
+    tokenProvider: () => authService.getValidAccessToken(environment),
+  });
+  try {
+    const response = await sdk.revokeShareToken(shareTokenId);
+    console.log(`✅ Share token revoked successfully:`, JSON.stringify(response, null, 2));
+  } catch (error) {
+    console.error('❌ Failed to revoke share token:', error);
     process.exit(1);
   }
 }

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1131,6 +1131,248 @@ describe('CLI Integration Tests', () => {
     });
   });
 
+  describe('grants create command', () => {
+    it('should create a grant successfully', async () => {
+      process.argv = [
+        'node',
+        'cli.js',
+        'grants',
+        'create',
+        '--resourceType',
+        'run',
+        '--resourceId',
+        'run-1',
+        '--subjectType',
+        'user',
+        '--subjectEmail',
+        'colleague@example.com',
+        '--relation',
+        'viewer',
+      ];
+
+      await main();
+
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        '✅ Grant created successfully:',
+        expect.stringContaining('grant_id')
+      );
+    });
+
+    it('should handle API errors for grants create', async () => {
+      server.use(http.post('*/v1/access/grants', () => HttpResponse.error()));
+
+      process.argv = [
+        'node',
+        'cli.js',
+        'grants',
+        'create',
+        '--resourceType',
+        'run',
+        '--resourceId',
+        'run-1',
+        '--subjectType',
+        'user',
+        '--relation',
+        'viewer',
+      ];
+
+      await main();
+
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        '❌ Failed to create grant:',
+        expect.any(Error)
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('grants list command', () => {
+    it('should list grants successfully', async () => {
+      process.argv = ['node', 'cli.js', 'grants', 'list', '--resourceId', 'run-1'];
+
+      await main();
+
+      expect(consoleSpy.log).toHaveBeenCalledWith('Grants:', expect.stringContaining('grant_id'));
+    });
+
+    it('should handle API errors for grants list', async () => {
+      server.use(http.get('*/v1/access/grants', () => HttpResponse.error()));
+
+      process.argv = ['node', 'cli.js', 'grants', 'list'];
+
+      await main();
+
+      expect(consoleSpy.error).toHaveBeenCalledWith('❌ Failed to list grants:', expect.any(Error));
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('grants get command', () => {
+    it('should get grant details successfully', async () => {
+      process.argv = ['node', 'cli.js', 'grants', 'get', 'grant-1'];
+
+      await main();
+
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        'Grant details for grant-1:',
+        expect.stringContaining('grant_id')
+      );
+    });
+
+    it('should handle API errors for grants get', async () => {
+      server.use(http.get('*/v1/access/grants/:grantId', () => HttpResponse.error()));
+
+      process.argv = ['node', 'cli.js', 'grants', 'get', 'grant-1'];
+
+      await main();
+
+      expect(consoleSpy.error).toHaveBeenCalledWith('❌ Failed to get grant:', expect.any(Error));
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('grants revoke command', () => {
+    it('should revoke a grant successfully', async () => {
+      process.argv = ['node', 'cli.js', 'grants', 'revoke', 'grant-1'];
+
+      await main();
+
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        '✅ Grant revoked successfully:',
+        expect.stringContaining('grant_id')
+      );
+    });
+
+    it('should handle API errors for grants revoke', async () => {
+      server.use(http.delete('*/v1/access/grants/:grantId', () => HttpResponse.error()));
+
+      process.argv = ['node', 'cli.js', 'grants', 'revoke', 'grant-1'];
+
+      await main();
+
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        '❌ Failed to revoke grant:',
+        expect.any(Error)
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('share-tokens create command', () => {
+    it('should create a share token successfully', async () => {
+      process.argv = [
+        'node',
+        'cli.js',
+        'share-tokens',
+        'create',
+        '--expiresAt',
+        '2026-01-01T00:00:00Z',
+      ];
+
+      await main();
+
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        '✅ Share token created successfully:',
+        expect.stringContaining('share_token')
+      );
+    });
+
+    it('should handle API errors for share-tokens create', async () => {
+      server.use(http.post('*/v1/access/share-tokens', () => HttpResponse.error()));
+
+      process.argv = ['node', 'cli.js', 'share-tokens', 'create'];
+
+      await main();
+
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        '❌ Failed to create share token:',
+        expect.any(Error)
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('share-tokens list command', () => {
+    it('should list share tokens successfully', async () => {
+      process.argv = ['node', 'cli.js', 'share-tokens', 'list', '--runId', 'run-1'];
+
+      await main();
+
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        'Share tokens:',
+        expect.stringContaining('share_token_id')
+      );
+    });
+
+    it('should handle API errors for share-tokens list', async () => {
+      server.use(http.get('*/v1/access/share-tokens', () => HttpResponse.error()));
+
+      process.argv = ['node', 'cli.js', 'share-tokens', 'list'];
+
+      await main();
+
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        '❌ Failed to list share tokens:',
+        expect.any(Error)
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('share-tokens get command', () => {
+    it('should get share token details successfully', async () => {
+      process.argv = ['node', 'cli.js', 'share-tokens', 'get', 'share-token-1'];
+
+      await main();
+
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        'Share token details for share-token-1:',
+        expect.stringContaining('share_token_id')
+      );
+    });
+
+    it('should handle API errors for share-tokens get', async () => {
+      server.use(http.get('*/v1/access/share-tokens/:shareTokenId', () => HttpResponse.error()));
+
+      process.argv = ['node', 'cli.js', 'share-tokens', 'get', 'share-token-1'];
+
+      await main();
+
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        '❌ Failed to get share token:',
+        expect.any(Error)
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('share-tokens revoke command', () => {
+    it('should revoke a share token successfully', async () => {
+      process.argv = ['node', 'cli.js', 'share-tokens', 'revoke', 'share-token-1'];
+
+      await main();
+
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        '✅ Share token revoked successfully:',
+        expect.stringContaining('share_token_id')
+      );
+    });
+
+    it('should handle API errors for share-tokens revoke', async () => {
+      server.use(http.delete('*/v1/access/share-tokens/:shareTokenId', () => HttpResponse.error()));
+
+      process.argv = ['node', 'cli.js', 'share-tokens', 'revoke', 'share-token-1'];
+
+      await main();
+
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        '❌ Failed to revoke share token:',
+        expect.any(Error)
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
   describe('unknown command handling', () => {
     it('should handle unknown command', async () => {
       process.argv = ['node', 'cli.js', 'unknown-command'];

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -26,9 +26,22 @@ import {
   handleStatus,
   handleLoginWithRefreshToken,
   getApplicationVersionDetails,
+  createGrant,
+  listGrants,
+  getGrant,
+  revokeGrant,
+  createShareToken,
+  listShareTokens,
+  getShareToken,
+  revokeShareToken,
 } from './cli-functions.js';
 import { EnvironmentKey, environmentConfig } from './utils/environment.js';
-import { AuthenticationError } from '@aignostics/sdk';
+import {
+  AuthenticationError,
+  type ResourceType,
+  type SubjectType,
+  type GrantRelation,
+} from '@aignostics/sdk';
 
 // Create a shared auth service instance for the CLI
 const authService = new AuthService(new FileSystemTokenStorage());
@@ -384,6 +397,215 @@ export async function main() {
             () => undefined
           )
           .demandCommand(1, 'You need at least one runs subcommand'),
+      () => undefined
+    )
+    .command(
+      'grants',
+      'Manage access grants',
+      grantsYargs =>
+        grantsYargs
+          .command(
+            'create',
+            'Create a grant to share access to a resource',
+            yargs =>
+              yargs
+                .option('resourceType', {
+                  describe: 'Type of resource to grant access to',
+                  type: 'string',
+                  choices: ['run', 'item', 'output_artifact', 'share_token'],
+                  demandOption: true,
+                })
+                .option('resourceId', {
+                  describe: 'ID of the resource to grant access to',
+                  type: 'string',
+                  demandOption: true,
+                })
+                .option('subjectType', {
+                  describe: 'Type of subject to grant access to',
+                  type: 'string',
+                  choices: ['user', 'organization_admin', 'organization_user', 'share_token'],
+                  demandOption: true,
+                })
+                .option('subjectId', {
+                  describe: 'ID of the subject to grant access to',
+                  type: 'string',
+                })
+                .option('subjectEmail', {
+                  describe: 'Email of the user subject to grant access to',
+                  type: 'string',
+                })
+                .option('relation', {
+                  describe: 'Relation to grant',
+                  type: 'string',
+                  choices: ['owner', 'editor', 'viewer'],
+                  demandOption: true,
+                }),
+            argv => {
+              const env = environmentSchema.parse(argv.environment);
+              return createGrant(env, authService, {
+                resourceType: argv.resourceType as ResourceType,
+                resourceId: argv.resourceId,
+                subjectType: argv.subjectType as SubjectType,
+                subjectId: argv.subjectId,
+                subjectEmail: argv.subjectEmail,
+                relation: argv.relation as GrantRelation,
+              });
+            }
+          )
+          .command(
+            'list',
+            'List grants',
+            yargs =>
+              yargs
+                .option('resourceType', {
+                  describe: 'Filter by resource type',
+                  type: 'string',
+                  choices: ['run', 'item', 'output_artifact', 'share_token'],
+                })
+                .option('resourceId', {
+                  describe: 'Filter by resource ID',
+                  type: 'string',
+                })
+                .option('subjectType', {
+                  describe: 'Filter by subject type',
+                  type: 'string',
+                  choices: ['user', 'organization_admin', 'organization_user', 'share_token'],
+                })
+                .option('subjectId', {
+                  describe: 'Filter by subject ID',
+                  type: 'string',
+                })
+                .option('revoked', {
+                  describe: 'Filter by revocation status',
+                  type: 'boolean',
+                })
+                .option('sort', {
+                  describe: 'Sort by field (e.g., "-created_at")',
+                  type: 'string',
+                }),
+            argv => {
+              const env = environmentSchema.parse(argv.environment);
+              return listGrants(env, authService, {
+                resourceType: argv.resourceType as ResourceType | undefined,
+                resourceId: argv.resourceId,
+                subjectType: argv.subjectType as SubjectType | undefined,
+                subjectId: argv.subjectId,
+                revoked: argv.revoked,
+                sort: argv.sort,
+              });
+            }
+          )
+          .command(
+            'get <grantId>',
+            'Get details of a specific grant',
+            yargs =>
+              yargs.positional('grantId', {
+                describe: 'Grant ID to get details for',
+                type: 'string',
+                demandOption: true,
+              }),
+            argv => {
+              const env = environmentSchema.parse(argv.environment);
+              return getGrant(env, authService, argv.grantId);
+            }
+          )
+          .command(
+            'revoke <grantId>',
+            'Revoke a specific grant',
+            yargs =>
+              yargs.positional('grantId', {
+                describe: 'Grant ID to revoke',
+                type: 'string',
+                demandOption: true,
+              }),
+            argv => {
+              const env = environmentSchema.parse(argv.environment);
+              return revokeGrant(env, authService, argv.grantId);
+            }
+          )
+          .demandCommand(1, 'You need at least one grants subcommand'),
+      () => undefined
+    )
+    .command(
+      'share-tokens',
+      'Manage share tokens',
+      shareTokensYargs =>
+        shareTokensYargs
+          .command(
+            'create',
+            'Create a share token',
+            yargs =>
+              yargs.option('expiresAt', {
+                describe: 'ISO 8601 expiration date/time for the share token',
+                type: 'string',
+              }),
+            argv => {
+              const env = environmentSchema.parse(argv.environment);
+              return createShareToken(env, authService, {
+                expiresAt: argv.expiresAt,
+              });
+            }
+          )
+          .command(
+            'list',
+            'List share tokens',
+            yargs =>
+              yargs
+                .option('runId', {
+                  describe: 'Filter by run ID',
+                  type: 'string',
+                })
+                .option('createdBy', {
+                  describe: 'Filter by share token creator',
+                  type: 'string',
+                })
+                .option('revoked', {
+                  describe: 'Filter by revocation status',
+                  type: 'boolean',
+                })
+                .option('sort', {
+                  describe: 'Sort by field (e.g., "-created_at")',
+                  type: 'string',
+                }),
+            argv => {
+              const env = environmentSchema.parse(argv.environment);
+              return listShareTokens(env, authService, {
+                runId: argv.runId,
+                createdBy: argv.createdBy,
+                revoked: argv.revoked,
+                sort: argv.sort,
+              });
+            }
+          )
+          .command(
+            'get <shareTokenId>',
+            'Get details of a specific share token',
+            yargs =>
+              yargs.positional('shareTokenId', {
+                describe: 'Share token ID to get details for',
+                type: 'string',
+                demandOption: true,
+              }),
+            argv => {
+              const env = environmentSchema.parse(argv.environment);
+              return getShareToken(env, authService, argv.shareTokenId);
+            }
+          )
+          .command(
+            'revoke <shareTokenId>',
+            'Revoke a specific share token',
+            yargs =>
+              yargs.positional('shareTokenId', {
+                describe: 'Share token ID to revoke',
+                type: 'string',
+                demandOption: true,
+              }),
+            argv => {
+              const env = environmentSchema.parse(argv.environment);
+              return revokeShareToken(env, authService, argv.shareTokenId);
+            }
+          )
+          .demandCommand(1, 'You need at least one share-tokens subcommand'),
       () => undefined
     )
     .command(

--- a/packages/sdk/src/platform-sdk.test.ts
+++ b/packages/sdk/src/platform-sdk.test.ts
@@ -797,4 +797,141 @@ describe('PlatformSDK', () => {
     await expect(sdk.getRun('test-run-id')).rejects.toThrow(APIError);
     await expect(sdk.getRun('test-run-id')).rejects.toThrow('Resource gone:');
   });
+
+  describe('grants', () => {
+    beforeEach(() => {
+      mockTokenProvider.mockResolvedValue('mocked-token');
+    });
+
+    it('should create a grant successfully', async () => {
+      setMockScenario('success');
+
+      const result = await sdk.createGrant({
+        resource_type: 'run',
+        resource_id: 'run-123',
+        subject_type: 'user',
+        subject_email: 'colleague@example.com',
+        relation: 'viewer',
+      });
+
+      expect(result).toHaveProperty('grant_id');
+    });
+
+    it('should handle create grant failure', async () => {
+      setMockScenario('validationError');
+
+      await expect(
+        sdk.createGrant({
+          resource_type: 'run',
+          resource_id: 'run-123',
+          subject_type: 'user',
+          relation: 'viewer',
+        })
+      ).rejects.toThrow(APIError);
+    });
+
+    it('should list grants successfully', async () => {
+      setMockScenario('success');
+
+      const result = await sdk.listGrants({ resourceType: 'run', resourceId: 'run-123' });
+
+      expect(Array.isArray(result)).toBe(true);
+    });
+
+    it('should handle list grants failure', async () => {
+      setMockScenario('internalServerError');
+
+      await expect(sdk.listGrants()).rejects.toThrow(APIError);
+    });
+
+    it('should get a grant successfully', async () => {
+      setMockScenario('success');
+
+      const result = await sdk.getGrant('grant-123');
+
+      expect(result).toHaveProperty('grant_id');
+    });
+
+    it('should handle get grant failure', async () => {
+      setMockScenario('notFoundError');
+
+      await expect(sdk.getGrant('grant-123')).rejects.toThrow(APIError);
+    });
+
+    it('should revoke a grant successfully', async () => {
+      setMockScenario('success');
+
+      const result = await sdk.revokeGrant('grant-123');
+
+      expect(result).toHaveProperty('grant_id');
+    });
+
+    it('should handle revoke grant failure', async () => {
+      setMockScenario('notFoundError');
+
+      await expect(sdk.revokeGrant('grant-123')).rejects.toThrow(APIError);
+    });
+  });
+
+  describe('share tokens', () => {
+    beforeEach(() => {
+      mockTokenProvider.mockResolvedValue('mocked-token');
+    });
+
+    it('should create a share token successfully', async () => {
+      setMockScenario('success');
+
+      const result = await sdk.createShareToken({ expires_at: null });
+
+      expect(result).toHaveProperty('share_token');
+    });
+
+    it('should handle create share token failure', async () => {
+      setMockScenario('validationError');
+
+      await expect(sdk.createShareToken({})).rejects.toThrow(APIError);
+    });
+
+    it('should list share tokens successfully', async () => {
+      setMockScenario('success');
+
+      const result = await sdk.listShareTokens({ runId: 'run-123' });
+
+      expect(Array.isArray(result)).toBe(true);
+    });
+
+    it('should handle list share tokens failure', async () => {
+      setMockScenario('internalServerError');
+
+      await expect(sdk.listShareTokens()).rejects.toThrow(APIError);
+    });
+
+    it('should get a share token successfully', async () => {
+      setMockScenario('success');
+
+      const result = await sdk.getShareToken('share-token-123');
+
+      expect(result).toHaveProperty('share_token_id');
+    });
+
+    it('should handle get share token failure', async () => {
+      setMockScenario('notFoundError');
+
+      await expect(sdk.getShareToken('share-token-123')).rejects.toThrow(APIError);
+    });
+
+    it('should revoke a share token successfully', async () => {
+      setMockScenario('success');
+
+      const result = await sdk.revokeShareToken('share-token-123');
+
+      expect(result).toHaveProperty('share_token_id');
+    });
+
+    it('should handle revoke share token failure', async () => {
+      setMockScenario('notFoundError');
+
+      await expect(sdk.revokeShareToken('share-token-123')).rejects.toThrow(APIError);
+    });
+  });
 });

--- a/packages/sdk/src/platform-sdk.ts
+++ b/packages/sdk/src/platform-sdk.ts
@@ -3,11 +3,19 @@ import {
   ApplicationReadResponse,
   ApplicationReadShortResponse,
   CustomMetadataUpdateResponse,
+  GrantCreateRequest,
+  GrantReadResponse,
+  GrantRelation,
   ItemState,
   ItemTerminationReason,
   PublicApi,
+  ResourceType,
   RunCreationRequest,
   RunCreationResponse,
+  ShareTokenCreateRequest,
+  ShareTokenCreateResponse,
+  ShareTokenReadResponse,
+  SubjectType,
   VersionReadResponse,
 } from './generated/index.js';
 import { APIError, AuthenticationError, UnexpectedError } from './errors.js';
@@ -157,6 +165,31 @@ export interface PlatformSDK {
   ): Promise<VersionReadResponse>;
   downloadArtifact(runId: string, artifactId: string): Promise<ArrayBuffer>;
   downloadArtifactStream(runId: string, artifactId: string): Promise<Readable>;
+  createGrant(request: GrantCreateRequest): Promise<GrantReadResponse>;
+  listGrants(options?: {
+    resourceType?: ResourceType;
+    resourceId?: string;
+    subjectType?: SubjectType;
+    subjectId?: string;
+    relation?: GrantRelation[];
+    revoked?: boolean;
+    page?: number;
+    pageSize?: number;
+    sort?: string[];
+  }): Promise<GrantReadResponse[]>;
+  getGrant(grantId: string): Promise<GrantReadResponse>;
+  revokeGrant(grantId: string): Promise<GrantReadResponse>;
+  createShareToken(request: ShareTokenCreateRequest): Promise<ShareTokenCreateResponse>;
+  listShareTokens(options?: {
+    runId?: string;
+    createdBy?: string;
+    revoked?: boolean;
+    page?: number;
+    pageSize?: number;
+    sort?: string[];
+  }): Promise<ShareTokenReadResponse[]>;
+  getShareToken(shareTokenId: string): Promise<ShareTokenReadResponse>;
+  revokeShareToken(shareTokenId: string): Promise<ShareTokenReadResponse>;
 }
 /**
  * Main SDK class for interacting with the Aignostics Platform
@@ -921,6 +954,265 @@ export class PlatformSDKHttp implements PlatformSDK {
         [403, 404, 410, 422]
       );
       return response.data as Readable;
+    } catch (error) {
+      handleRequestError(error);
+    }
+  }
+
+  /**
+   * Create a grant to share access to a resource with a subject (user or organization)
+   *
+   * @param request - The grant creation request
+   * @returns A promise that resolves to the created grant
+   * @throws {Error} If the request fails due to network issues, authentication problems, invalid request data, or API errors
+   *
+   * @example
+   * ```typescript
+   * const sdk = new PlatformSDKHttp({ tokenProvider: () => 'your-token' });
+   *
+   * const grant = await sdk.createGrant({
+   *   resource_type: 'run',
+   *   resource_id: 'run-123',
+   *   subject_type: 'user',
+   *   subject_email: 'colleague@example.com',
+   *   relation: 'viewer',
+   * });
+   * ```
+   */
+  async createGrant(request: GrantCreateRequest): Promise<GrantReadResponse> {
+    const client = await this.#getClient();
+    try {
+      const response = await client.createGrantV1AccessGrantsPost({
+        grantCreateRequest: request,
+      });
+      return response.data;
+    } catch (error) {
+      handleRequestError(error);
+    }
+  }
+
+  /**
+   * List grants, optionally filtered by resource, subject, relation, or revocation status
+   *
+   * @param options - Optional filters and pagination/sort options
+   * @returns A promise that resolves to an array of grants
+   * @throws {Error} If the request fails due to network issues, authentication problems, or API errors
+   *
+   * @example
+   * ```typescript
+   * const sdk = new PlatformSDKHttp({ tokenProvider: () => 'your-token' });
+   *
+   * const grants = await sdk.listGrants({ resourceType: 'run', resourceId: 'run-123' });
+   * ```
+   */
+  async listGrants({
+    resourceType,
+    resourceId,
+    subjectType,
+    subjectId,
+    relation,
+    revoked,
+    page,
+    pageSize,
+    sort,
+  }: {
+    resourceType?: ResourceType;
+    resourceId?: string;
+    subjectType?: SubjectType;
+    subjectId?: string;
+    relation?: GrantRelation[];
+    revoked?: boolean;
+    page?: number;
+    pageSize?: number;
+    sort?: string[];
+  } = {}): Promise<GrantReadResponse[]> {
+    const client = await this.#getClient();
+    try {
+      const response = await client.listGrantsV1AccessGrantsGet({
+        resourceType,
+        resourceId,
+        subjectType,
+        subjectId,
+        relation,
+        revoked,
+        page,
+        pageSize,
+        sort,
+      });
+      return response.data;
+    } catch (error) {
+      handleRequestError(error);
+    }
+  }
+
+  /**
+   * Get a grant by its ID
+   *
+   * @param grantId - The unique identifier of the grant
+   * @returns A promise that resolves to the grant details
+   * @throws {Error} If the request fails due to network issues, authentication problems, invalid grant ID, or API errors
+   *
+   * @example
+   * ```typescript
+   * const sdk = new PlatformSDKHttp({ tokenProvider: () => 'your-token' });
+   *
+   * const grant = await sdk.getGrant('grant-123');
+   * ```
+   */
+  async getGrant(grantId: string): Promise<GrantReadResponse> {
+    const client = await this.#getClient();
+    try {
+      const response = await client.getGrantV1AccessGrantsGrantIdGet({ grantId });
+      return response.data;
+    } catch (error) {
+      handleRequestError(error);
+    }
+  }
+
+  /**
+   * Revoke a grant by its ID
+   *
+   * @param grantId - The unique identifier of the grant to revoke
+   * @returns A promise that resolves to the revoked grant details
+   * @throws {Error} If the request fails due to network issues, authentication problems, invalid grant ID, or API errors
+   *
+   * @example
+   * ```typescript
+   * const sdk = new PlatformSDKHttp({ tokenProvider: () => 'your-token' });
+   *
+   * await sdk.revokeGrant('grant-123');
+   * ```
+   */
+  async revokeGrant(grantId: string): Promise<GrantReadResponse> {
+    const client = await this.#getClient();
+    try {
+      const response = await client.revokeGrantV1AccessGrantsGrantIdDelete({ grantId });
+      return response.data;
+    } catch (error) {
+      handleRequestError(error);
+    }
+  }
+
+  /**
+   * Create a share token. The returned share_token value is shown only once and is never stored.
+   * Use `createGrant` with `subject_type: 'share_token'` to grant access to a resource.
+   *
+   * @param request - The share token creation request
+   * @returns A promise that resolves to the created share token, including the one-time token value
+   * @throws {Error} If the request fails due to network issues, authentication problems, invalid request data, or API errors
+   *
+   * @example
+   * ```typescript
+   * const sdk = new PlatformSDKHttp({ tokenProvider: () => 'your-token' });
+   *
+   * const shareToken = await sdk.createShareToken({ expires_at: '2026-01-01T00:00:00Z' });
+   * console.log(shareToken.share_token); // Only shown once
+   * ```
+   */
+  async createShareToken(request: ShareTokenCreateRequest): Promise<ShareTokenCreateResponse> {
+    const client = await this.#getClient();
+    try {
+      const response = await client.createShareTokenV1AccessShareTokensPost({
+        shareTokenCreateRequest: request,
+      });
+      return response.data;
+    } catch (error) {
+      handleRequestError(error);
+    }
+  }
+
+  /**
+   * List share tokens, optionally filtered by run, creator, or revocation status
+   *
+   * @param options - Optional filters and pagination/sort options
+   * @returns A promise that resolves to an array of share tokens
+   * @throws {Error} If the request fails due to network issues, authentication problems, or API errors
+   *
+   * @example
+   * ```typescript
+   * const sdk = new PlatformSDKHttp({ tokenProvider: () => 'your-token' });
+   *
+   * const shareTokens = await sdk.listShareTokens({ runId: 'run-123' });
+   * ```
+   */
+  async listShareTokens({
+    runId,
+    createdBy,
+    revoked,
+    page,
+    pageSize,
+    sort,
+  }: {
+    runId?: string;
+    createdBy?: string;
+    revoked?: boolean;
+    page?: number;
+    pageSize?: number;
+    sort?: string[];
+  } = {}): Promise<ShareTokenReadResponse[]> {
+    const client = await this.#getClient();
+    try {
+      const response = await client.listShareTokensV1AccessShareTokensGet({
+        runId,
+        createdBy,
+        revoked,
+        page,
+        pageSize,
+        sort,
+      });
+      return response.data;
+    } catch (error) {
+      handleRequestError(error);
+    }
+  }
+
+  /**
+   * Get a share token by its ID
+   *
+   * @param shareTokenId - The unique identifier of the share token
+   * @returns A promise that resolves to the share token details (excludes the token value)
+   * @throws {Error} If the request fails due to network issues, authentication problems, invalid share token ID, or API errors
+   *
+   * @example
+   * ```typescript
+   * const sdk = new PlatformSDKHttp({ tokenProvider: () => 'your-token' });
+   *
+   * const shareToken = await sdk.getShareToken('share-token-123');
+   * ```
+   */
+  async getShareToken(shareTokenId: string): Promise<ShareTokenReadResponse> {
+    const client = await this.#getClient();
+    try {
+      const response = await client.getShareTokenV1AccessShareTokensShareTokenIdGet({
+        shareTokenId,
+      });
+      return response.data;
+    } catch (error) {
+      handleRequestError(error);
+    }
+  }
+
+  /**
+   * Revoke a share token by its ID. Invalidates the credential regardless of any active grants.
+   *
+   * @param shareTokenId - The unique identifier of the share token to revoke
+   * @returns A promise that resolves to the revoked share token details
+   * @throws {Error} If the request fails due to network issues, authentication problems, invalid share token ID, or API errors
+   *
+   * @example
+   * ```typescript
+   * const sdk = new PlatformSDKHttp({ tokenProvider: () => 'your-token' });
+   *
+   * await sdk.revokeShareToken('share-token-123');
+   * ```
+   */
+  async revokeShareToken(shareTokenId: string): Promise<ShareTokenReadResponse> {
+    const client = await this.#getClient();
+    try {
+      const response = await client.revokeShareTokenV1AccessShareTokensShareTokenIdDelete({
+        shareTokenId,
+      });
+      return response.data;
     } catch (error) {
       handleRequestError(error);
     }

--- a/packages/sdk/src/test-utils/http-mocks.ts
+++ b/packages/sdk/src/test-utils/http-mocks.ts
@@ -14,6 +14,9 @@ import type {
   InputArtifact,
   OutputArtifact,
   CustomMetadataUpdateResponse,
+  GrantReadResponse,
+  ShareTokenCreateResponse,
+  ShareTokenReadResponse,
 } from '../generated/index.js';
 
 // Factories for generating mock data
@@ -162,6 +165,33 @@ const customMetadataUpdateResponseFactory = Factory.define<CustomMetadataUpdateR
   custom_metadata_checksum: faker.string.alphanumeric(8),
 }));
 
+const grantFactory = Factory.define<GrantReadResponse>(() => ({
+  grant_id: faker.string.uuid(),
+  resource_type: 'run',
+  resource_id: faker.string.uuid(),
+  subject_type: 'user',
+  subject_id: faker.string.uuid(),
+  relation: 'viewer',
+  created_by: faker.string.uuid(),
+  created_at: faker.date.past().toISOString(),
+  revoked: false,
+}));
+
+const shareTokenCreateResponseFactory = Factory.define<ShareTokenCreateResponse>(() => ({
+  share_token_id: faker.string.uuid(),
+  share_token: faker.string.alphanumeric(32),
+  created_at: faker.date.past().toISOString(),
+  expires_at: null,
+  revoked: false,
+}));
+
+const shareTokenReadResponseFactory = Factory.define<ShareTokenReadResponse>(() => ({
+  share_token_id: faker.string.uuid(),
+  created_at: faker.date.past().toISOString(),
+  expires_at: null,
+  revoked: false,
+}));
+
 /**
  * Mock responses for API endpoints using factories
  */
@@ -195,6 +225,20 @@ export const mockResponses = {
 
   // Mock custom metadata update response
   customMetadataUpdateSuccess: customMetadataUpdateResponseFactory.build(),
+  // Mock grant response
+  grantSuccess: grantFactory.build(),
+
+  // Mock grants list response
+  grantsSuccess: grantFactory.buildList(2),
+
+  // Mock share token creation response (includes the one-time token)
+  shareTokenCreateSuccess: shareTokenCreateResponseFactory.build(),
+
+  // Mock share token read response
+  shareTokenSuccess: shareTokenReadResponseFactory.build(),
+
+  // Mock share tokens list response
+  shareTokensSuccess: shareTokenReadResponseFactory.buildList(2),
 
   // Mock error response
   error: {
@@ -227,6 +271,9 @@ export const factories = {
   itemResult: itemResultFactory,
   outputArtifact: outputArtifactFactory,
   customMetadataUpdateResponse: customMetadataUpdateResponseFactory,
+  grant: grantFactory,
+  shareTokenCreateResponse: shareTokenCreateResponseFactory,
+  shareTokenReadResponse: shareTokenReadResponseFactory,
 };
 
 /**
@@ -276,6 +323,30 @@ export const handlers = {
         status: 200,
         headers: { 'Content-Type': 'application/octet-stream' },
       });
+    }),
+    http.post('*/v1/access/grants', () => {
+      return HttpResponse.json(mockResponses.grantSuccess, { status: 201 });
+    }),
+    http.get('*/v1/access/grants', () => {
+      return HttpResponse.json(mockResponses.grantsSuccess, { status: 200 });
+    }),
+    http.get('*/v1/access/grants/:grantId', () => {
+      return HttpResponse.json(mockResponses.grantSuccess, { status: 200 });
+    }),
+    http.delete('*/v1/access/grants/:grantId', () => {
+      return HttpResponse.json(mockResponses.grantSuccess, { status: 200 });
+    }),
+    http.post('*/v1/access/share-tokens', () => {
+      return HttpResponse.json(mockResponses.shareTokenCreateSuccess, { status: 201 });
+    }),
+    http.get('*/v1/access/share-tokens', () => {
+      return HttpResponse.json(mockResponses.shareTokensSuccess, { status: 200 });
+    }),
+    http.get('*/v1/access/share-tokens/:shareTokenId', () => {
+      return HttpResponse.json(mockResponses.shareTokenSuccess, { status: 200 });
+    }),
+    http.delete('*/v1/access/share-tokens/:shareTokenId', () => {
+      return HttpResponse.json(mockResponses.shareTokenSuccess, { status: 200 });
     }),
   ],
 
@@ -357,6 +428,30 @@ export const handlers = {
     http.get('*/v1/runs/:runId/artifacts/:artifactId/file', () => {
       return HttpResponse.json(mockResponses.error, { status: 404 });
     }),
+    http.post('*/v1/access/grants', () => {
+      return HttpResponse.json(mockResponses.error, { status: 404 });
+    }),
+    http.get('*/v1/access/grants', () => {
+      return HttpResponse.json(mockResponses.error, { status: 404 });
+    }),
+    http.get('*/v1/access/grants/:grantId', () => {
+      return HttpResponse.json(mockResponses.error, { status: 404 });
+    }),
+    http.delete('*/v1/access/grants/:grantId', () => {
+      return HttpResponse.json(mockResponses.error, { status: 404 });
+    }),
+    http.post('*/v1/access/share-tokens', () => {
+      return HttpResponse.json(mockResponses.error, { status: 404 });
+    }),
+    http.get('*/v1/access/share-tokens', () => {
+      return HttpResponse.json(mockResponses.error, { status: 404 });
+    }),
+    http.get('*/v1/access/share-tokens/:shareTokenId', () => {
+      return HttpResponse.json(mockResponses.error, { status: 404 });
+    }),
+    http.delete('*/v1/access/share-tokens/:shareTokenId', () => {
+      return HttpResponse.json(mockResponses.error, { status: 404 });
+    }),
   ],
 
   validationError: [
@@ -397,6 +492,30 @@ export const handlers = {
       return HttpResponse.json(mockResponses.validationError, { status: 422 });
     }),
     http.get('*/v1/runs/:runId/artifacts/:artifactId/file', () => {
+      return HttpResponse.json(mockResponses.validationError, { status: 422 });
+    }),
+    http.post('*/v1/access/grants', () => {
+      return HttpResponse.json(mockResponses.validationError, { status: 422 });
+    }),
+    http.get('*/v1/access/grants', () => {
+      return HttpResponse.json(mockResponses.validationError, { status: 422 });
+    }),
+    http.get('*/v1/access/grants/:grantId', () => {
+      return HttpResponse.json(mockResponses.validationError, { status: 422 });
+    }),
+    http.delete('*/v1/access/grants/:grantId', () => {
+      return HttpResponse.json(mockResponses.validationError, { status: 422 });
+    }),
+    http.post('*/v1/access/share-tokens', () => {
+      return HttpResponse.json(mockResponses.validationError, { status: 422 });
+    }),
+    http.get('*/v1/access/share-tokens', () => {
+      return HttpResponse.json(mockResponses.validationError, { status: 422 });
+    }),
+    http.get('*/v1/access/share-tokens/:shareTokenId', () => {
+      return HttpResponse.json(mockResponses.validationError, { status: 422 });
+    }),
+    http.delete('*/v1/access/share-tokens/:shareTokenId', () => {
       return HttpResponse.json(mockResponses.validationError, { status: 422 });
     }),
   ],
@@ -441,6 +560,30 @@ export const handlers = {
     http.get('*/v1/runs/:runId/artifacts/:artifactId/file', () => {
       return HttpResponse.json(mockResponses.error, { status: 500 });
     }),
+    http.post('*/v1/access/grants', () => {
+      return HttpResponse.json(mockResponses.error, { status: 500 });
+    }),
+    http.get('*/v1/access/grants', () => {
+      return HttpResponse.json(mockResponses.error, { status: 500 });
+    }),
+    http.get('*/v1/access/grants/:grantId', () => {
+      return HttpResponse.json(mockResponses.error, { status: 500 });
+    }),
+    http.delete('*/v1/access/grants/:grantId', () => {
+      return HttpResponse.json(mockResponses.error, { status: 500 });
+    }),
+    http.post('*/v1/access/share-tokens', () => {
+      return HttpResponse.json(mockResponses.error, { status: 500 });
+    }),
+    http.get('*/v1/access/share-tokens', () => {
+      return HttpResponse.json(mockResponses.error, { status: 500 });
+    }),
+    http.get('*/v1/access/share-tokens/:shareTokenId', () => {
+      return HttpResponse.json(mockResponses.error, { status: 500 });
+    }),
+    http.delete('*/v1/access/share-tokens/:shareTokenId', () => {
+      return HttpResponse.json(mockResponses.error, { status: 500 });
+    }),
   ],
 
   // Network error (connection failure)
@@ -482,6 +625,30 @@ export const handlers = {
       return HttpResponse.error();
     }),
     http.get('*/v1/runs/:runId/artifacts/:artifactId/file', () => {
+      return HttpResponse.error();
+    }),
+    http.post('*/v1/access/grants', () => {
+      return HttpResponse.error();
+    }),
+    http.get('*/v1/access/grants', () => {
+      return HttpResponse.error();
+    }),
+    http.get('*/v1/access/grants/:grantId', () => {
+      return HttpResponse.error();
+    }),
+    http.delete('*/v1/access/grants/:grantId', () => {
+      return HttpResponse.error();
+    }),
+    http.post('*/v1/access/share-tokens', () => {
+      return HttpResponse.error();
+    }),
+    http.get('*/v1/access/share-tokens', () => {
+      return HttpResponse.error();
+    }),
+    http.get('*/v1/access/share-tokens/:shareTokenId', () => {
+      return HttpResponse.error();
+    }),
+    http.delete('*/v1/access/share-tokens/:shareTokenId', () => {
       return HttpResponse.error();
     }),
   ],


### PR DESCRIPTION
## Summary

Implements [TSSDK-62](https://aignx.atlassian.net/browse/TSSDK-62): SDK methods and CLI commands for managing access grants and share tokens, enabling users to share runs/resources with other users or organizations.

Maps to the `/v1/access/grants` and `/v1/access/share-tokens` endpoints (already present in the vendored OpenAPI spec / generated client).

## Changes

### SDK (`@aignostics/sdk`)
- `createGrant`, `listGrants`, `getGrant`, `revokeGrant`
- `createShareToken`, `listShareTokens`, `getShareToken`, `revokeShareToken`
- Mock factories/handlers for all test scenarios (success, empty, not found, validation error, server error, network error)
- Unit tests for all new methods

### CLI (`@aignostics/cli`)
- New `grants create/list/get/revoke` commands
- New `share-tokens create/list/get/revoke` commands
- Unit tests for the CLI functions and yargs command wiring
- README usage examples

## Testing

- `npm run lint` — passes
- `npm run build` — passes
- `npm run test` — all tests pass (SDK 98.88% coverage, CLI 98.22% coverage)

## Notes

- Includes a separate `chore: regenerate ATTRIBUTIONS.md` commit — this was pre-existing drift on `main`, auto-regenerated by the pre-commit hook and unrelated to this feature.


[TSSDK-62]: https://aignx.atlassian.net/browse/TSSDK-62?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ