### PR TITLE
feat(sdk): TSSDK-71 do not leak auth header in errors

### DIFF
--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -1,3 +1,5 @@
+import type { AxiosError } from 'axios';
+
 export type ErrorCode =
   'AUTHENTICATION_ERROR' | 'API_ERROR' | 'CONFIGURATION_ERROR' | 'UNEXPECTED_ERROR';
 
@@ -119,5 +121,20 @@ export class UnexpectedError extends BaseError {
    */
   constructor(message: string, options: BaseErrorOptions = {}) {
     super(message, 'UNEXPECTED_ERROR', options);
+  }
+}
+
+/**
+ * Strips the Authorization header from an Axios error so it is never exposed to
+ * SDK consumers.
+ */
+export function redactAuthorizationHeader(error: AxiosError): void {
+  const headers = error.config?.headers;
+  if (headers && typeof headers === 'object') {
+    for (const key of Object.keys(headers)) {
+      if (key.toLowerCase() === 'authorization') {
+        headers[key] = 'Bearer [redacted]';
+      }
+    }
   }
 }

--- a/packages/sdk/src/platform-sdk.test.ts
+++ b/packages/sdk/src/platform-sdk.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { http, HttpResponse } from 'msw';
+import { isAxiosError, type AxiosError } from 'axios';
 import { PlatformSDKHttp } from './platform-sdk.js';
 import { APIError, AuthenticationError } from './errors.js';
 import { setMockScenario, server } from './test-utils/http-mocks.js';
@@ -796,6 +797,26 @@ describe('PlatformSDK', () => {
 
     await expect(sdk.getRun('test-run-id')).rejects.toThrow(APIError);
     await expect(sdk.getRun('test-run-id')).rejects.toThrow('Resource gone:');
+  });
+
+  it('should redact the Authorization header from the original axios error', async () => {
+    const secretToken = 'secret-token';
+    mockTokenProvider.mockResolvedValue(secretToken);
+    setMockScenario('internalServerError');
+
+    let caught: APIError;
+    try {
+      await sdk.listApplications();
+    } catch (error) {
+      caught = error as APIError;
+    }
+
+    expect(caught!).toBeInstanceOf(APIError);
+    const originalError = caught!.originalError as AxiosError;
+    expect(isAxiosError(originalError)).toBe(true);
+
+    const headers = originalError.config!.headers;
+    expect(headers.Authorization).toBe('Bearer [redacted]');
   });
 
   describe('grants', () => {

--- a/packages/sdk/src/platform-sdk.ts
+++ b/packages/sdk/src/platform-sdk.ts
@@ -18,7 +18,12 @@ import {
   SubjectType,
   VersionReadResponse,
 } from './generated/index.js';
-import { APIError, AuthenticationError, UnexpectedError } from './errors.js';
+import {
+  APIError,
+  AuthenticationError,
+  UnexpectedError,
+  redactAuthorizationHeader,
+} from './errors.js';
 import { isAxiosError } from 'axios';
 import z from 'zod';
 import { processApplicationRun } from './entities/application-run/process-application-run.js';
@@ -42,6 +47,7 @@ const errorResponseSchema = z.union([validationErrorSchema, z.any()]);
 
 function handleRequestError(error: unknown): never {
   if (isAxiosError(error)) {
+    redactAuthorizationHeader(error);
     switch (error.status) {
       case 422: {
         throw new APIError(`Validation error: ${error.message}`, {


### PR DESCRIPTION
_handleRequestError_ in _platform-sdk.ts_ attached the raw Axios error as _originalError_ on thrown _APIError_/_UnexpectedError_ instances. That error's _config.headers_ carries the request's _Authorization_ bearer token in plaintext, which leaks out through _JSON.stringify_/_toJSON()_ or direct property access if a consumer logs or forwards the caught error to an error tracker.

* added _redactAuthorizationHeader_ in _errors.ts_, called at the top of _handleRequestError_ before the status-code switch;
* it overwrites _config.headers.Authorization_ with a redacted placeholder when present;
* covered with a unit test in _platform-sdk.test.ts_ asserting the token is redacted on the thrown error's _originalError_.