### PR TITLE
fix(cli): read package.json version lazily in handleInfo

### DIFF
--- a/docs/TESTING_CONVENTION.md
+++ b/docs/TESTING_CONVENTION.md
@@ -83,6 +83,13 @@ npm run test:coverage
 - Group related tests in `describe` blocks
 - Use descriptive test names that explain the behavior being tested
 
+## Mocking Scope
+
+- Prefer `vi.mock('module')` (auto-mock, no factory) over `vi.mock('module', () => ({ fx: /* implementation */ }))`. An inline factory hardcodes behavior for the whole file; auto-mocking replaces every export with a `vi.fn()` and lets each test configure only what it needs via `vi.mocked(fx).mockReturnValue(...)` / `.mockResolvedValue(...)` etc.
+- Only write a `vi.mock('module', () => (...))` factory when auto-mock genuinely doesn't work for the case (e.g. you need to keep some real exports alongside mocked ones, via `importOriginal`).
+- This keeps test setup close to the test it affects, avoids one test's mock silently changing another's behavior, and makes it obvious which tests depend on which mocked behavior.
+- Once `mockReset` is enabled (planned), mock implementations/return values set at module/`describe` scope are wiped before every test. Any default mock behavior that needs to persist across tests (e.g. a default resolved value used by most tests in a file) must be (re-)established in a `beforeEach`, not inline at module or `describe` level.
+
 ## Coverage Requirements
 
 - Overall coverage: 85% minimum

--- a/packages/cli/src/cli-functions.spec.ts
+++ b/packages/cli/src/cli-functions.spec.ts
@@ -105,11 +105,16 @@ const mockAuthService = {
   loginWithRefreshToken: vi.fn(),
 } as unknown as AuthService;
 
-// Mock package.json
-vi.mock("../../package.json", () => ({
-  default: { version: "0.0.0-development" },
-  version: "0.0.0-development",
-}));
+// cli-functions.ts reads package.json synchronously via fs.readFileSync inside
+// handleInfo(). ESM named exports aren't spy-able directly, so mock the module,
+// defaulting to the real implementation so other tests are unaffected;
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  return {
+    ...actual,
+    readFileSync: vi.fn(actual.readFileSync),
+  };
+});
 
 describe("CLI Functions Unit Tests", () => {
   let consoleSpy: {
@@ -138,13 +143,15 @@ describe("CLI Functions Unit Tests", () => {
 
   describe("handleInfo", () => {
     it("should display SDK information", () => {
+      const mockVersion = "1.0.0";
+      vi.mocked(fs.readFileSync).mockReturnValueOnce(
+        JSON.stringify({ version: mockVersion }),
+      );
+
       handleInfo();
 
       expect(consoleSpy.log).toHaveBeenCalledWith("Aignostics Platform SDK");
-      expect(consoleSpy.log).toHaveBeenCalledWith(
-        "Version:",
-        "0.0.0-development",
-      );
+      expect(consoleSpy.log).toHaveBeenCalledWith("Version:", mockVersion);
     });
   });
 

--- a/packages/cli/src/cli-functions.ts
+++ b/packages/cli/src/cli-functions.ts
@@ -22,13 +22,13 @@ import { join } from 'path';
 import crypto from 'crypto';
 import { environmentConfig, EnvironmentKey } from './utils/environment.js';
 
-// Read package.json synchronously for CommonJS compatibility
-const packageJsonPath = join(__dirname, '../package.json');
-const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as {
-  version: string;
-};
-
 export function handleInfo(): void {
+  // Read package.json synchronously for CommonJS compatibility
+  const packageJsonPath = join(__dirname, '../package.json');
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as {
+    version: string;
+  };
+
   console.log('Aignostics Platform SDK');
   console.log('Version:', packageJson.version);
 }


### PR DESCRIPTION
## Problem

`handleInfo()` read `packages/cli/package.json` once at module load time into a module-level constant. This caused the release-please release PR to fail: release-please bumps the version in `package.json`, but since the CLI's `dist` output baked in the version read before that bump (at the previous build), the expected vs. actual version mismatched.

## Fix

Move the `readFileSync` call inside `handleInfo()` so the version is read fresh from disk on every call, always reflecting the current `package.json`.

## Also included

Added a "Mocking Scope" section to `docs/TESTING_CONVENTION.md` codifying a convention surfaced while fixing the corresponding test: prefer `vi.mock('module')` (auto-mock) plus per-test `vi.mocked(fx).mockReturnValue(...)` over inline `vi.mock('module', () => ({...}))` factories, and keep persistent mock defaults in `beforeEach` (relevant once `mockReset` is enabled).

## Testing

- `npm run test --workspace @aignostics/cli -- cli-functions.spec.ts` — 82/82 passing
- `npm run lint:cli` — 0 warnings/errors
- `npm run format:check` — passing