### PR TITLE
chore(deps): upgrade typescript to 6.0.3

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -2669,7 +2669,7 @@ SOFTWARE.
 
 ## @oxfmt/binding-android-arm-eabi
 
-**Version:** 0.60.0  
+**Version:** 0.61.0  
 **License:** MIT
 
 ```
@@ -2698,7 +2698,7 @@ SOFTWARE.
 
 ## @oxfmt/binding-android-arm64
 
-**Version:** 0.60.0  
+**Version:** 0.61.0  
 **License:** MIT
 
 ```
@@ -2727,7 +2727,7 @@ SOFTWARE.
 
 ## @oxfmt/binding-darwin-arm64
 
-**Version:** 0.60.0  
+**Version:** 0.61.0  
 **License:** MIT
 
 ```
@@ -2756,7 +2756,7 @@ SOFTWARE.
 
 ## @oxfmt/binding-darwin-x64
 
-**Version:** 0.60.0  
+**Version:** 0.61.0  
 **License:** MIT
 
 ```
@@ -2785,7 +2785,7 @@ SOFTWARE.
 
 ## @oxfmt/binding-freebsd-x64
 
-**Version:** 0.60.0  
+**Version:** 0.61.0  
 **License:** MIT
 
 ```
@@ -2814,7 +2814,7 @@ SOFTWARE.
 
 ## @oxfmt/binding-linux-arm-gnueabihf
 
-**Version:** 0.60.0  
+**Version:** 0.61.0  
 **License:** MIT
 
 ```
@@ -2843,7 +2843,7 @@ SOFTWARE.
 
 ## @oxfmt/binding-linux-arm-musleabihf
 
-**Version:** 0.60.0  
+**Version:** 0.61.0  
 **License:** MIT
 
 ```
@@ -2872,7 +2872,7 @@ SOFTWARE.
 
 ## @oxfmt/binding-linux-arm64-gnu
 
-**Version:** 0.60.0  
+**Version:** 0.61.0  
 **License:** MIT
 
 ```
@@ -2901,7 +2901,7 @@ SOFTWARE.
 
 ## @oxfmt/binding-linux-arm64-musl
 
-**Version:** 0.60.0  
+**Version:** 0.61.0  
 **License:** MIT
 
 ```
@@ -2930,7 +2930,7 @@ SOFTWARE.
 
 ## @oxfmt/binding-linux-ppc64-gnu
 
-**Version:** 0.60.0  
+**Version:** 0.61.0  
 **License:** MIT
 
 ```
@@ -2959,7 +2959,7 @@ SOFTWARE.
 
 ## @oxfmt/binding-linux-riscv64-gnu
 
-**Version:** 0.60.0  
+**Version:** 0.61.0  
 **License:** MIT
 
 ```
@@ -2988,7 +2988,7 @@ SOFTWARE.
 
 ## @oxfmt/binding-linux-riscv64-musl
 
-**Version:** 0.60.0  
+**Version:** 0.61.0  
 **License:** MIT
 
 ```
@@ -3017,7 +3017,7 @@ SOFTWARE.
 
 ## @oxfmt/binding-linux-s390x-gnu
 
-**Version:** 0.60.0  
+**Version:** 0.61.0  
 **License:** MIT
 
 ```
@@ -3046,7 +3046,7 @@ SOFTWARE.
 
 ## @oxfmt/binding-linux-x64-gnu
 
-**Version:** 0.60.0  
+**Version:** 0.61.0  
 **License:** MIT
 
 ```
@@ -3075,7 +3075,7 @@ SOFTWARE.
 
 ## @oxfmt/binding-linux-x64-musl
 
-**Version:** 0.60.0  
+**Version:** 0.61.0  
 **License:** MIT
 
 ```
@@ -3104,7 +3104,7 @@ SOFTWARE.
 
 ## @oxfmt/binding-openharmony-arm64
 
-**Version:** 0.60.0  
+**Version:** 0.61.0  
 **License:** MIT
 
 ```
@@ -3133,7 +3133,7 @@ SOFTWARE.
 
 ## @oxfmt/binding-win32-arm64-msvc
 
-**Version:** 0.60.0  
+**Version:** 0.61.0  
 **License:** MIT
 
 ```
@@ -3162,7 +3162,7 @@ SOFTWARE.
 
 ## @oxfmt/binding-win32-ia32-msvc
 
-**Version:** 0.60.0  
+**Version:** 0.61.0  
 **License:** MIT
 
 ```
@@ -3191,7 +3191,7 @@ SOFTWARE.
 
 ## @oxfmt/binding-win32-x64-msvc
 
-**Version:** 0.60.0  
+**Version:** 0.61.0  
 **License:** MIT
 
 ```
@@ -3397,7 +3397,7 @@ SOFTWARE.
 
 ## @oxlint/binding-android-arm-eabi
 
-**Version:** 1.75.0  
+**Version:** 1.76.0  
 **License:** MIT
 
 ```
@@ -3426,7 +3426,7 @@ SOFTWARE.
 
 ## @oxlint/binding-android-arm64
 
-**Version:** 1.75.0  
+**Version:** 1.76.0  
 **License:** MIT
 
 ```
@@ -3455,7 +3455,7 @@ SOFTWARE.
 
 ## @oxlint/binding-darwin-arm64
 
-**Version:** 1.75.0  
+**Version:** 1.76.0  
 **License:** MIT
 
 ```
@@ -3484,7 +3484,7 @@ SOFTWARE.
 
 ## @oxlint/binding-darwin-x64
 
-**Version:** 1.75.0  
+**Version:** 1.76.0  
 **License:** MIT
 
 ```
@@ -3513,7 +3513,7 @@ SOFTWARE.
 
 ## @oxlint/binding-freebsd-x64
 
-**Version:** 1.75.0  
+**Version:** 1.76.0  
 **License:** MIT
 
 ```
@@ -3542,7 +3542,7 @@ SOFTWARE.
 
 ## @oxlint/binding-linux-arm-gnueabihf
 
-**Version:** 1.75.0  
+**Version:** 1.76.0  
 **License:** MIT
 
 ```
@@ -3571,7 +3571,7 @@ SOFTWARE.
 
 ## @oxlint/binding-linux-arm-musleabihf
 
-**Version:** 1.75.0  
+**Version:** 1.76.0  
 **License:** MIT
 
 ```
@@ -3600,7 +3600,7 @@ SOFTWARE.
 
 ## @oxlint/binding-linux-arm64-gnu
 
-**Version:** 1.75.0  
+**Version:** 1.76.0  
 **License:** MIT
 
 ```
@@ -3629,7 +3629,7 @@ SOFTWARE.
 
 ## @oxlint/binding-linux-arm64-musl
 
-**Version:** 1.75.0  
+**Version:** 1.76.0  
 **License:** MIT
 
 ```
@@ -3658,7 +3658,7 @@ SOFTWARE.
 
 ## @oxlint/binding-linux-ppc64-gnu
 
-**Version:** 1.75.0  
+**Version:** 1.76.0  
 **License:** MIT
 
 ```
@@ -3687,7 +3687,7 @@ SOFTWARE.
 
 ## @oxlint/binding-linux-riscv64-gnu
 
-**Version:** 1.75.0  
+**Version:** 1.76.0  
 **License:** MIT
 
 ```
@@ -3716,7 +3716,7 @@ SOFTWARE.
 
 ## @oxlint/binding-linux-riscv64-musl
 
-**Version:** 1.75.0  
+**Version:** 1.76.0  
 **License:** MIT
 
 ```
@@ -3745,7 +3745,7 @@ SOFTWARE.
 
 ## @oxlint/binding-linux-s390x-gnu
 
-**Version:** 1.75.0  
+**Version:** 1.76.0  
 **License:** MIT
 
 ```
@@ -3774,7 +3774,7 @@ SOFTWARE.
 
 ## @oxlint/binding-linux-x64-gnu
 
-**Version:** 1.75.0  
+**Version:** 1.76.0  
 **License:** MIT
 
 ```
@@ -3803,7 +3803,7 @@ SOFTWARE.
 
 ## @oxlint/binding-linux-x64-musl
 
-**Version:** 1.75.0  
+**Version:** 1.76.0  
 **License:** MIT
 
 ```
@@ -3832,7 +3832,7 @@ SOFTWARE.
 
 ## @oxlint/binding-openharmony-arm64
 
-**Version:** 1.75.0  
+**Version:** 1.76.0  
 **License:** MIT
 
 ```
@@ -3861,7 +3861,7 @@ SOFTWARE.
 
 ## @oxlint/binding-win32-arm64-msvc
 
-**Version:** 1.75.0  
+**Version:** 1.76.0  
 **License:** MIT
 
 ```
@@ -3890,7 +3890,7 @@ SOFTWARE.
 
 ## @oxlint/binding-win32-ia32-msvc
 
-**Version:** 1.75.0  
+**Version:** 1.76.0  
 **License:** MIT
 
 ```
@@ -3919,7 +3919,7 @@ SOFTWARE.
 
 ## @oxlint/binding-win32-x64-msvc
 
-**Version:** 1.75.0  
+**Version:** 1.76.0  
 **License:** MIT
 
 ```
@@ -15163,7 +15163,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ## oxfmt
 
-**Version:** 0.60.0  
+**Version:** 0.61.0  
 **License:** MIT
 
 ```
@@ -15195,7 +15195,7 @@ SOFTWARE.
 
 ## oxlint
 
-**Version:** 1.75.0  
+**Version:** 1.76.0  
 **License:** MIT
 
 ```
@@ -19757,7 +19757,7 @@ Apache License
 
 ## typescript
 
-**Version:** 5.9.3  
+**Version:** 6.0.3  
 **License:** Apache-2.0
 
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "tsdown": "0.22.14",
         "turbo": "2.10.7",
         "typedoc": "0.28.20",
-        "typescript": "5.9.3",
+        "typescript": "6.0.3",
         "vitest": "3.2.7"
       },
       "engines": {
@@ -8734,9 +8734,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -9337,7 +9337,7 @@
     },
     "packages/sdk": {
       "name": "@aignostics/sdk",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.18.1",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "tsdown": "0.22.14",
     "turbo": "2.10.7",
     "typedoc": "0.28.20",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "3.2.7"
   },
   "engines": {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -22,6 +22,7 @@
     "emitDecoratorMetadata": true,
     "removeComments": false,
     "preserveConstEnums": true,
+    "rootDir": ".",
     "paths": {
       "@aignostics/sdk": ["./packages/sdk/src/index.ts"],
       "@aignostics/sdk/test": ["./packages/sdk/src/test-utils/http-mocks.ts"],


### PR DESCRIPTION
## Summary

Upgrades the monorepo's TypeScript devDependency from `5.9.3` to the latest `6.x` release (`6.0.3`).

- Bumped `typescript` in root `package.json` (the only place it's pinned as an actual dependency; `packages/sdk`/`packages/cli` only reference it in `keywords`)
- Updated `package-lock.json` accordingly
- Fixed a TS 6.0 breaking change: the default `rootDir` changed from an inferred common source directory to the directory containing `tsconfig.json`. This broke `packages/cli`'s typecheck, since it consumes `packages/sdk` source files directly through the `@aignostics/sdk` paths alias in `tsconfig.base.json`. Fixed by explicitly setting `"rootDir": "."` in `tsconfig.base.json` (resolves to the repo root, covering both packages). This has no effect on emitted output since both packages' `typecheck` script runs `tsc --noEmit` and the actual build output is produced by `tsdown`, not `tsc`.

## Verification

- `npm run lint` ✅
- `npm run format:check` ✅
- `npm run typecheck` ✅
- `npm run test` ✅
- `npm run build` ✅

Closes TSSDK-75